### PR TITLE
Allow users to set their own sesrvergroup within the bootstrap helper

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -1,7 +1,7 @@
 package org.littleshoot.proxy;
 
 import org.littleshoot.proxy.impl.ThreadPoolConfiguration;
-
+import org.littleshot.proxy.impl.ServerGroup;
 import java.net.InetSocketAddress;
 
 /**
@@ -268,6 +268,15 @@ public interface HttpProxyServerBootstrap {
      */
     HttpProxyServerBootstrap withServerResolver(HostResolver serverResolver);
 
+    /**
+    * Specify a custom {@link ServerGroup} to use for managing this server's resources and such.
+    * If one isn't provided, a default one will be created using the {@link ThreadPoolConfiguration} provided
+    * 
+    * @param group A custom server group
+    * @return
+    */
+    HttpProxyServerBootstrap withServerGroup(ServerGroup group);
+    
     /**
      * <p>
      * Add an {@link ActivityTracker} for tracking activity in this proxy.

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -1,7 +1,7 @@
 package org.littleshoot.proxy;
 
 import org.littleshoot.proxy.impl.ThreadPoolConfiguration;
-import org.littleshot.proxy.impl.ServerGroup;
+import org.littleshoot.proxy.impl.ServerGroup;
 import java.net.InetSocketAddress;
 
 /**

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -820,7 +820,8 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 	@Override
 	public HttpProxyServerBootstrap withServerGroup(
 		ServerGroup group) {
-	this.serverGroup = group;
+	   this.serverGroup = group;
+	   return this;
 	}
 		
         @Override

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -817,7 +817,12 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             this.serverResolver = serverResolver;
             return this;
         }
-
+	@Override
+	public HttpProxyServerBootstrap withServerGroup(
+		ServerGroup group) {
+	this.serverGroup = group;
+	}
+		
         @Override
         public HttpProxyServerBootstrap plusActivityTracker(
                 ActivityTracker activityTracker) {


### PR DESCRIPTION
Fairly self explanatory.

In my use case, I open a lot of ports with (somewhat) different rules for each. I find it easier than writing some sort of convuluted chaining method with http sessions etcetra, this way is faster and easier to implement for clients. Unfortunately, creating tons of servergroups really stresses out my server, and it would be more efficient to share resources between the different littleproxy servers.

So, this is the solution! I tried to keep with the current design spec. Thank you very much for creating this fork btw!