### PR TITLE
Complete the JavaDoc comments #11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
 
     <inceptionYear>2009</inceptionYear>
 
-    <!-- disable doclint, since Java 8 treats warnings as errors -->
     <profiles>
         <profile>
             <id>release</id>
@@ -105,8 +104,6 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                             <source>${java.version}</source>
-                            <!-- disable doclint, since Java 8 treats warnings as errors -->
-                            <doclint>none</doclint>
                         </configuration>
                         <executions>
                             <execution>
@@ -495,8 +492,6 @@
                     <links>
                         <link>http://netty.io/4.0/api/</link>
                     </links>
-                    <!-- disable doclint, since Java 8 treats warnings as errors -->
-                    <doclint>none</doclint>
                 </configuration>
             </plugin>
 
@@ -585,8 +580,6 @@
                     <links>
                         <link>http://netty.io/4.0/api/</link>
                     </links>
-                    <!-- disable doclint, since Java 8 treats warnings as errors -->
-                    <doclint>none</doclint>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1108,7 +1108,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * response headers to reflect that it was proxied.
      * 
      * @param httpResponse
-     * @return
      */
     private void modifyResponseHeadersToReflectProxying(
             HttpResponse httpResponse) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -462,7 +462,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * Disconnects. This will wait for pending writes to be flushed before
      * disconnecting.
      * 
-     * @return Future<Void> for when we're done disconnecting. If we weren't
+     * @return {@code Future<Void>} for when we're done disconnecting. If we weren't
      *         connected, this returns null.
      */
     Future<Void> disconnect() {


### PR DESCRIPTION
Fixes those javadoc comments that actually cause the Maven build to fail. The 100 or so more are logged as warnings.