### PR TITLE
Do not warn about missing tags in javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
+                        <doclint>all,-missing</doclint>
                         <show>private</show>
                         <source>${java.version}</source>
                         <links>

--- a/src/main/java/org/littleshoot/proxy/ActivityTracker.java
+++ b/src/main/java/org/littleshoot/proxy/ActivityTracker.java
@@ -20,25 +20,17 @@ public interface ActivityTracker {
 
     /**
      * Record that a client connected.
-     * 
-     * @param clientAddress
      */
     void clientConnected(InetSocketAddress clientAddress);
 
     /**
      * Record that a client's SSL handshake completed.
-     * 
-     * @param clientAddress
-     * @param sslSession
      */
     void clientSSLHandshakeSucceeded(InetSocketAddress clientAddress,
             SSLSession sslSession);
 
     /**
      * Record that a client disconnected.
-     * 
-     * @param clientAddress
-     * @param sslSession
      */
     void clientDisconnected(InetSocketAddress clientAddress,
             SSLSession sslSession);

--- a/src/main/java/org/littleshoot/proxy/ChainedProxy.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxy.java
@@ -26,16 +26,12 @@ public interface ChainedProxy extends SslEngineSource {
     /**
      * (Optional) ensure that the connection is opened from a specific local
      * address (useful when doing NAT traversal).
-     * 
-     * @return
      */
     InetSocketAddress getLocalAddress();
 
     /**
      * Tell LittleProxy what kind of TransportProtocol to use to communicate
      * with the chained proxy.
-     * 
-     * @return
      */
     TransportProtocol getTransportProtocol();
 
@@ -73,8 +69,6 @@ public interface ChainedProxy extends SslEngineSource {
 
     /**
      * Filters requests on their way to the chained proxy.
-     * 
-     * @param httpObject
      */
     void filterRequest(HttpObject httpObject);
 

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyManager.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyManager.java
@@ -30,10 +30,6 @@ public interface ChainedProxyManager {
      * To keep the proxy from attempting any connection, leave the list blank.
      * This will cause the proxy to return a 502 response.
      * </p>
-     * 
-     * @param httpRequest
-     * @param chainedProxies
-     * @param clientDetails
      */
     void lookupChainedProxies(HttpRequest httpRequest,
                               Queue<ChainedProxy> chainedProxies,

--- a/src/main/java/org/littleshoot/proxy/FlowContext.java
+++ b/src/main/java/org/littleshoot/proxy/FlowContext.java
@@ -26,8 +26,6 @@ public class FlowContext {
 
     /**
      * The address of the client.
-     * 
-     * @return
      */
     public InetSocketAddress getClientAddress() {
         return clientAddress;
@@ -36,8 +34,6 @@ public class FlowContext {
     /**
      * If using SSL, this returns the {@link SSLSession} on the client
      * connection.
-     * 
-     * @return
      */
     public SSLSession getClientSslSession() {
         return clientSslSession;

--- a/src/main/java/org/littleshoot/proxy/FullFlowContext.java
+++ b/src/main/java/org/littleshoot/proxy/FullFlowContext.java
@@ -20,8 +20,6 @@ public class FullFlowContext extends FlowContext {
 
     /**
      * The host and port for the server (i.e. the ultimate endpoint).
-     * 
-     * @return
      */
     public String getServerHostAndPort() {
         return serverHostAndPort;
@@ -29,8 +27,6 @@ public class FullFlowContext extends FlowContext {
 
     /**
      * The chained proxy (if proxy chaining).
-     * 
-     * @return
      */
     public ChainedProxy getChainedProxy() {
         return chainedProxy;

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersSource.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersSource.java
@@ -13,9 +13,6 @@ public interface HttpFiltersSource {
     /**
      * Return an {@link HttpFilters} object for this request if and only if we
      * want to filter the request and/or its responses.
-     * 
-     * @param originalRequest
-     * @return
      */
     HttpFilters filterRequest(HttpRequest originalRequest,
             ChannelHandlerContext ctx);
@@ -29,8 +26,6 @@ public interface HttpFiltersSource {
      * received from the client, with its content already decompressed (in case
      * the client was compressing it). If the request size exceeds the maximum
      * buffer size, the request will fail.
-     * 
-     * @return
      */
     int getMaximumRequestBufferSizeInBytes();
 
@@ -43,8 +38,6 @@ public interface HttpFiltersSource {
      * received from the server, with its content already decompressed (in case
      * the server was compressing it). If the response size exceeds the maximum
      * buffer size, the response will fail.
-     * 
-     * @return
      */
     int getMaximumResponseBufferSizeInBytes();
 }

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
@@ -51,8 +51,6 @@ public interface HttpProxyServer {
 
     /**
      * Return the address on which this proxy is listening.
-     * 
-     * @return
      */
     InetSocketAddress getListenAddress();
 
@@ -60,8 +58,6 @@ public interface HttpProxyServer {
      * <p>
      * Set the read/write throttle bandwidths (in bytes/second) for this proxy.
      * </p>
-     * @param readThrottleBytesPerSecond
-     * @param writeThrottleBytesPerSecond
      */
     void setThrottle(long readThrottleBytesPerSecond, long writeThrottleBytesPerSecond);
 }

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -20,9 +20,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = LittleProxy
      * </p>
-     * 
-     * @param name
-     * @return
      */
     HttpProxyServerBootstrap withName(String name);
 
@@ -34,9 +31,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = TCP
      * </p>
-     * 
-     * @param transportProtocol
-     * @return
      */
     HttpProxyServerBootstrap withTransportProtocol(
             TransportProtocol transportProtocol);
@@ -49,9 +43,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = [bound ip]:8080
      * </p>
-     * 
-     * @param address
-     * @return
      */
     HttpProxyServerBootstrap withAddress(InetSocketAddress address);
 
@@ -63,9 +54,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = 8080
      * </p>
-     * 
-     * @param port
-     * @return
      */
     HttpProxyServerBootstrap withPort(int port);
 
@@ -77,9 +65,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = true
      * </p>
-     * 
-     * @param allowLocalOnly
-     * @return
      */
     HttpProxyServerBootstrap withAllowLocalOnly(boolean allowLocalOnly);
 
@@ -105,9 +90,6 @@ public interface HttpProxyServerBootstrap {
      * Note - This and {@link #withManInTheMiddle(MitmManager)} are
      * mutually exclusive.
      * </p>
-     * 
-     * @param sslEngineSource
-     * @return
      */
     HttpProxyServerBootstrap withSslEngineSource(
             SslEngineSource sslEngineSource);
@@ -121,9 +103,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = true
      * </p>
-     * 
-     * @param authenticateSslClients
-     * @return
      */
     HttpProxyServerBootstrap withAuthenticateSslClients(
             boolean authenticateSslClients);
@@ -137,9 +116,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = null
      * </p>
-     * 
-     * @param proxyAuthenticator
-     * @return
      */
     HttpProxyServerBootstrap withProxyAuthenticator(
             ProxyAuthenticator proxyAuthenticator);
@@ -153,9 +129,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = null
      * </p>
-     * 
-     * @param chainProxyManager
-     * @return
      */
     HttpProxyServerBootstrap withChainProxyManager(
             ChainedProxyManager chainProxyManager);
@@ -174,9 +147,6 @@ public interface HttpProxyServerBootstrap {
      * Note - This and {@link #withSslEngineSource(SslEngineSource)} are
      * mutually exclusive.
      * </p>
-     * 
-     * @param mitmManager
-     * @return
      */
     HttpProxyServerBootstrap withManInTheMiddle(
             MitmManager mitmManager);
@@ -190,9 +160,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = null
      * </p>
-     * 
-     * @param filtersSource
-     * @return
      */
     HttpProxyServerBootstrap withFiltersSource(
             HttpFiltersSource filtersSource);
@@ -206,9 +173,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = false
      * </p>
-     * 
-     * @param useDnsSec
-     * @return
      */
     HttpProxyServerBootstrap withUseDnsSec(
             boolean useDnsSec);
@@ -221,9 +185,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = false
      * </p>
-     * 
-     * @param transparent
-     * @return
      */
     HttpProxyServerBootstrap withTransparent(
             boolean transparent);
@@ -237,9 +198,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = 70
      * </p>
-     * 
-     * @param idleConnectionTimeout
-     * @return
      */
     HttpProxyServerBootstrap withIdleConnectionTimeout(
             int idleConnectionTimeout);
@@ -253,18 +211,12 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Default = 40000
      * </p>
-     * 
-     * @param connectTimeout
-     * @return
      */
     HttpProxyServerBootstrap withConnectTimeout(
             int connectTimeout);
 
     /**
      * Specify a custom {@link HostResolver} for resolving server addresses.
-     * 
-     * @param serverResolver
-     * @return
      */
     HttpProxyServerBootstrap withServerResolver(HostResolver serverResolver);
 
@@ -273,7 +225,6 @@ public interface HttpProxyServerBootstrap {
     * If one isn't provided, a default one will be created using the {@link ThreadPoolConfiguration} provided
     * 
     * @param group A custom server group
-    * @return
     */
     HttpProxyServerBootstrap withServerGroup(ServerGroup group);
     
@@ -281,9 +232,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Add an {@link ActivityTracker} for tracking activity in this proxy.
      * </p>
-     * 
-     * @param activityTracker
-     * @return
      */
     HttpProxyServerBootstrap plusActivityTracker(ActivityTracker activityTracker);
 
@@ -291,9 +239,6 @@ public interface HttpProxyServerBootstrap {
      * <p>
      * Specify the read and/or write bandwidth throttles for this proxy server. 0 indicates not throttling.
      * </p>
-     * @param readThrottleBytesPerSecond
-     * @param writeThrottleBytesPerSecond
-     * @return
      */
     HttpProxyServerBootstrap withThrottling(long readThrottleBytesPerSecond, long writeThrottleBytesPerSecond);
 

--- a/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
@@ -21,8 +21,6 @@ public interface ProxyAuthenticator {
      * The realm value to be used in the request for proxy authentication 
      * ("Proxy-Authenticate" header). Returning null will cause the string
      * "Restricted Files" to be used by default.
-     * 
-     * @return
      */
     String getRealm();
 }

--- a/src/main/java/org/littleshoot/proxy/SslEngineSource.java
+++ b/src/main/java/org/littleshoot/proxy/SslEngineSource.java
@@ -10,8 +10,6 @@ public interface SslEngineSource {
     /**
      * Returns an {@link SSLEngine} to use for a server connection from
      * LittleProxy to the client.
-     * 
-     * @return
      */
     SSLEngine newSslEngine();
 
@@ -26,7 +24,6 @@ public interface SslEngineSource {
      *            to start a client connection to the server.
      * @param peerPort
      *            to start a client connection to the server.
-     * @return
      */
     SSLEngine newSslEngine(String peerHost, int peerPort);
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -198,9 +198,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * Note - the "server" could be a chained proxy, not the final endpoint for
      * the request.
      * </p>
-     * 
-     * @param httpRequest
-     * @return
      */
     private ConnectionState doReadHTTPInitial(HttpRequest httpRequest) {
         // Make a copy of the original request
@@ -528,8 +525,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     /**
      * Called when {@link ProxyToServerConnection} starts its connection flow.
-     * 
-     * @param serverConnection
      */
     protected void serverConnectionFlowStarted(
             ProxyToServerConnection serverConnection) {
@@ -540,9 +535,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * If the {@link ProxyToServerConnection} completes its connection lifecycle
      * successfully, this method is called to let us know about it.
-     * 
-     * @param serverConnection
-     * @param shouldForwardInitialRequest
      */
     protected void serverConnectionSucceeded(
             ProxyToServerConnection serverConnection,
@@ -633,8 +625,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * On disconnect of the server, track that we have one fewer connected
      * servers and then disconnect the client if necessary.
-     * 
-     * @param serverConnection
      */
     protected void serverDisconnected(ProxyToServerConnection serverConnection) {
         numberOfCurrentlyConnectedServers.decrementAndGet();
@@ -684,8 +674,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     /**
      * When a server becomes saturated, we stop reading from the client.
-     * 
-     * @param serverConnection
      */
     synchronized protected void serverBecameSaturated(
             ProxyToServerConnection serverConnection) {
@@ -698,8 +686,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * When a server becomes writeable, we check to see if all servers are
      * writeable and if they are, we resume reading.
-     * 
-     * @param serverConnection
      */
     synchronized protected void serverBecameWriteable(
             ProxyToServerConnection serverConnection) {
@@ -753,8 +739,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * Regarding the Javadoc of {@link HttpObjectAggregator} it's needed to have
      * the {@link HttpResponseEncoder} or {@link io.netty.handler.codec.http.HttpRequestEncoder} before the
      * {@link HttpObjectAggregator} in the {@link ChannelPipeline}.
-     * 
-     * @param pipeline
      */
     private void initChannelPipeline(ChannelPipeline pipeline) {
         LOG.debug("Configuring ChannelPipeline");
@@ -839,11 +823,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     /**
      * Determine whether or not the client connection should be closed.
-     * 
-     * @param req
-     * @param res
-     * @param httpObject
-     * @return
      */
     private boolean shouldCloseClientConnection(HttpRequest req,
             HttpResponse res, HttpObject httpObject) {
@@ -957,9 +936,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * provided or the credentials were wrong, this writes a 407 response to the
      * client.
      * </p>
-     * 
-     * @param request
-     * @return
      */
     private boolean authenticationRequired(HttpRequest request) {
 
@@ -1031,9 +1007,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     /**
      * Copy the given {@link HttpRequest} verbatim.
-     * 
-     * @param original
-     * @return
      */
     private HttpRequest copy(HttpRequest original) {
         if (original instanceof FullHttpRequest) {
@@ -1050,8 +1023,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * Chunked encoding is an HTTP 1.1 feature, but sometimes we get a chunked
      * response that reports its HTTP version as 1.0. In this case, we change it
      * to 1.1.
-     * 
-     * @param httpResponse
      */
     private void fixHttpVersionHeaderIfNecessary(HttpResponse httpResponse) {
         String te = httpResponse.headers().get(
@@ -1068,8 +1039,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * If and only if our proxy is not running in transparent mode, modify the
      * request headers to reflect that it was proxied.
-     * 
-     * @param httpRequest
      */
     private void modifyRequestHeadersToReflectProxying(HttpRequest httpRequest) {
         if (isNextHopOriginServer()) {
@@ -1132,8 +1101,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * If and only if our proxy is not running in transparent mode, modify the
      * response headers to reflect that it was proxied.
-     * 
-     * @param httpResponse
      */
     private void modifyResponseHeadersToReflectProxying(
             HttpResponse httpResponse) {
@@ -1329,9 +1296,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     /**
      * Identify the host and port for a request.
-     * 
-     * @param httpRequest
-     * @return
      */
     private String identifyHostAndPort(HttpRequest httpRequest) {
         String hostAndPort = ProxyUtils.parseHostAndPort(httpRequest);

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
@@ -50,9 +50,6 @@ class ConnectionFlow {
 
     /**
      * Add a {@link ConnectionFlowStep} to the beginning of this flow.
-     * 
-     * @param step
-     * @return
      */
     ConnectionFlow first(ConnectionFlowStep step) {
         steps.addFirst(step);
@@ -61,9 +58,6 @@ class ConnectionFlow {
 
     /**
      * Add a {@link ConnectionFlowStep} to the end of this flow.
-     * 
-     * @param step
-     * @return
      */
     ConnectionFlow then(ConnectionFlowStep step) {
         steps.addLast(step);
@@ -75,8 +69,6 @@ class ConnectionFlow {
      * {@link ProxyToServerConnection} are passed to this method, which passes
      * it on to {@link ConnectionFlowStep#read(ConnectionFlow, Object)} for the
      * current {@link ConnectionFlowStep}.
-     * 
-     * @param msg
      */
     void read(Object msg) {
         if (this.currentStep != null) {
@@ -144,8 +136,6 @@ class ConnectionFlow {
     /**
      * Does the work of processing the current step, checking the result and
      * handling success/failure.
-     * 
-     * @param LOG
      */
     @SuppressWarnings("unchecked")
     private void doProcessCurrentStep(final ProxyConnectionLogger LOG) {

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlowStep.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlowStep.java
@@ -38,8 +38,6 @@ abstract class ConnectionFlowStep {
     /**
      * Indicates whether or not to suppress the initial request. Defaults to
      * false, can be overridden.
-     * 
-     * @return
      */
     boolean shouldSuppressInitialRequest() {
         return false;
@@ -55,9 +53,6 @@ abstract class ConnectionFlowStep {
      * If this step modifies the pipeline, for example by adding/removing
      * handlers, it's best to make it execute on the event loop.
      * </p>
-     * 
-     * 
-     * @return
      */
     boolean shouldExecuteOnEventLoop() {
         return true;
@@ -66,8 +61,6 @@ abstract class ConnectionFlowStep {
     /**
      * Implement this method to actually do the work involved in this step of
      * the flow.
-     * 
-     * @return
      */
     protected abstract Future execute();
 
@@ -76,8 +69,6 @@ abstract class ConnectionFlowStep {
      * this method. The default implementation simply continues with the flow.
      * Other implementations may choose to not continue and instead wait for a
      * message or something like that.
-     * 
-     * @param flow
      */
     void onSuccess(ConnectionFlow flow) {
         flow.advance();

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -127,8 +127,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 
     /**
      * Bootstrap a new {@link DefaultHttpProxyServer} starting from scratch.
-     *
-     * @return
      */
     public static HttpProxyServerBootstrap bootstrap() {
         return new DefaultHttpProxyServerBootstrap();
@@ -137,9 +135,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     /**
      * Bootstrap a new {@link DefaultHttpProxyServer} using defaults from the
      * given file.
-     *
-     * @param path
-     * @return
      */
     public static HttpProxyServerBootstrap bootstrapFromFile(String path) {
         final File propsFile = new File(path);
@@ -277,12 +272,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 
     /**
      * Creates a new GlobalTrafficShapingHandler for this HttpProxyServer, using this proxy's proxyToServerEventLoop.
-     *
-     * @param transportProtocol
-     * @param readThrottleBytesPerSecond
-     * @param writeThrottleBytesPerSecond
-     *
-     * @return
      */
     private GlobalTrafficShapingHandler createGlobalTrafficShapingHandler(TransportProtocol transportProtocol, long readThrottleBytesPerSecond, long writeThrottleBytesPerSecond) {
         EventLoopGroup proxyToServerEventLoop = this.getProxyToServerWorkerFor(transportProtocol);
@@ -443,8 +432,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 
     /**
      * Register a new {@link Channel} with this server, for later closing.
-     *
-     * @param channel
      */
     protected void registerChannel(Channel channel) {
         allChannels.add(channel);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -104,8 +104,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
     /**
      * Read is invoked automatically by Netty as messages arrive on the socket.
-     * 
-     * @param msg
      */
     protected void read(Object msg) {
         LOG.debug("Reading: {}", msg);
@@ -132,8 +130,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
     /**
      * Handles reading {@link HttpObject}s.
-     * 
-     * @param httpObject
      */
     @SuppressWarnings("unchecked")
     private void readHTTP(HttpObject httpObject) {
@@ -193,24 +189,17 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * Implement this to handle reading the initial object (e.g.
      * {@link HttpRequest} or {@link HttpResponse}).
-     * 
-     * @param httpObject
-     * @return
      */
     protected abstract ConnectionState readHTTPInitial(I httpObject);
 
     /**
      * Implement this to handle reading a chunk in a chunked transfer.
-     * 
-     * @param chunk
      */
     protected abstract void readHTTPChunk(HttpContent chunk);
 
     /**
      * Implement this to handle reading a raw buffer as they are used in HTTP
      * tunneling.
-     * 
-     * @param buf
      */
     protected abstract void readRaw(ByteBuf buf);
 
@@ -221,8 +210,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * This method is called by users of the ProxyConnection to send stuff out
      * over the socket.
-     * 
-     * @param msg
      */
     void write(Object msg) {
         if (msg instanceof ReferenceCounted) {
@@ -249,8 +236,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
     /**
      * Writes HttpObjects to the connection asynchronously.
-     * 
-     * @param httpObject
      */
     protected void writeHttp(HttpObject httpObject) {
         if (ProxyUtils.isLastChunk(httpObject)) {
@@ -264,8 +249,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
     /**
      * Writes raw buffers to the connection.
-     * 
-     * @param buf
      */
     protected void writeRaw(ByteBuf buf) {
         writeToChannel(buf);
@@ -421,9 +404,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * Enables decompression and aggregation of content, which is useful for
      * certain types of filtering activity.
-     * 
-     * @param pipeline
-     * @param numberOfBytesToBuffer
      */
     protected void aggregateContentForFiltering(ChannelPipeline pipeline,
             int numberOfBytesToBuffer) {
@@ -449,8 +429,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * Override this to handle exceptions that occurred during asynchronous
      * processing on the {@link Channel}.
-     * 
-     * @param cause
      */
     protected void exceptionCaught(Throwable cause) {
     }
@@ -492,8 +470,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * Indicates whether or not this connection is saturated (i.e. not
      * writeable).
-     * 
-     * @return
      */
     protected boolean isSaturated() {
         return !this.channel.isWritable();
@@ -501,9 +477,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
 
     /**
      * Utility for checking current state.
-     * 
-     * @param state
-     * @return
      */
     protected boolean is(ConnectionState state) {
         return currentState == state;
@@ -512,17 +485,13 @@ abstract class ProxyConnection<I extends HttpObject> extends
     /**
      * If this connection is currently in the process of going through a
      * {@link ConnectionFlow}, this will return true.
-     * 
-     * @return
      */
     protected boolean isConnecting() {
         return currentState.isPartOfConnectionFlow();
     }
 
     /**
-     * Udpates the current state to the given value.
-     * 
-     * @param state
+     * Updates the current state to the given value.
      */
     protected void become(ConnectionState state) {
         this.currentState = state;
@@ -564,7 +533,6 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * 
      * @param httpRequest
      *            Filter attached to the give HttpRequest (if any)
-     * @return
      */
     protected HttpFilters getHttpFiltersFromProxyServer(HttpRequest httpRequest) {
         return proxyServer.getFiltersSource().filterRequest(httpRequest, ctx);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -174,14 +174,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     
     /**
      * Create a new ProxyToServerConnection.
-     * 
-     * @param proxyServer
-     * @param clientConnection
-     * @param serverHostAndPort
-     * @param initialFilters
-     * @param initialHttpRequest
-     * @return
-     * @throws UnknownHostException
      */
     static ProxyToServerConnection create(DefaultHttpProxyServer proxyServer,
             ClientToProxyConnection clientConnection,
@@ -342,9 +334,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Like {@link #write(Object)} and also sets the current filters to the
      * given value.
-     * 
-     * @param msg
-     * @param filters
      */
     void write(Object msg, HttpFilters filters) {
         this.currentFilters = filters;
@@ -543,8 +532,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Keeps track of the current HttpResponse so that we can associate its
      * headers with future related chunks for this same transfer.
-     * 
-     * @param response
      */
     private void rememberCurrentResponse(HttpResponse response) {
         LOG.debug("Remembering the current response.");
@@ -558,8 +545,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
     /**
      * Respond to the client with the given {@link HttpObject}.
-     * 
-     * @param httpObject
      */
     private void respondWith(HttpObject httpObject) {
         clientConnection.respond(this, currentFilters, currentHttpRequest,
@@ -1095,9 +1080,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * Regarding the Javadoc of {@link HttpObjectAggregator} it's needed to have
      * the {@link HttpResponseEncoder} or {@link HttpRequestEncoder} before the
      * {@link HttpObjectAggregator} in the {@link ChannelPipeline}.
-     * 
-     * @param pipeline
-     * @param httpRequest
      */
     private void initChannelPipeline(ChannelPipeline pipeline, HttpRequest httpRequest) {
 
@@ -1218,6 +1200,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * We track statistics on bytes, requests and responses by adding handlers
      * at the appropriate parts of the pipeline (see initChannelPipeline()).
      **************************************************************************/
+
     private final BytesReadMonitor bytesReadMonitor = new BytesReadMonitor() {
         @Override
         protected void bytesRead(int numberOfBytes) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -131,10 +131,6 @@ public class ProxyUtils {
      * represents the last chunk of a transfer.
      * 
      * @see io.netty.handler.codec.http.LastHttpContent
-     * 
-     * @param httpObject
-     * @return
-     * 
      */
     public static boolean isLastChunk(final HttpObject httpObject) {
         return httpObject instanceof LastHttpContent;
@@ -145,9 +141,6 @@ public class ProxyUtils {
      * chunks that will follow.
      * 
      * @see io.netty.handler.codec.http.FullHttpMessage
-     * 
-     * @param httpObject
-     * @return
      */
     public static boolean isChunked(final HttpObject httpObject) {
         return !isLastChunk(httpObject);

--- a/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
@@ -124,8 +124,6 @@ public abstract class AbstractProxyTest {
     /**
      * Override this to specify a username to use when authenticating with
      * proxy.
-     * 
-     * @return
      */
     protected String getUsername() {
         return null;
@@ -134,8 +132,6 @@ public abstract class AbstractProxyTest {
     /**
      * Override this to specify a password to use when authenticating with
      * proxy.
-     * 
-     * @return
      */
     protected String getPassword() {
         return null;

--- a/src/test/java/org/littleshoot/proxy/BaseProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseProxyTest.java
@@ -37,8 +37,6 @@ public abstract class BaseProxyTest extends AbstractProxyTest {
     /**
      * This test tests a HEAD followed by a GET for the same resource, making
      * sure that the requests complete and that the Content-Length matches.
-     * 
-     * @throws Exception
      */
     @Test
     public void testHeadRequestFollowedByGet() throws Exception {

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
@@ -261,9 +261,6 @@ public class ProxyUtilsTest {
      * Helper method that asserts that 'sdch' is removed from the
      * 'Accept-Encoding' header.
      *
-     * @param inputEncodings The input value of the 'Accept-Encoding' header
-     *        that should be used as the basis for the assertion check.
-
      * @param inputEncodings The input list that maps to the values of the
      *        'Accept-Encoding' header that should be used as the basis for the
      *        assertion check.

--- a/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
+++ b/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
@@ -21,7 +21,6 @@ public class SocketClientUtil {
      *
      * @param string string to write
      * @param socket socket to write to
-     * @throws IOException
      */
     public static void writeStringToSocket(String string, Socket socket) throws IOException {
         OutputStream out = socket.getOutputStream();
@@ -54,7 +53,6 @@ public class SocketClientUtil {
      *
      * @param socket socket to test
      * @return true if the socket is open and can be written to, otherwise false
-     * @throws IOException
      */
     public static boolean isSocketReadyToWrite(Socket socket) throws IOException {
         OutputStream out = socket.getOutputStream();
@@ -77,7 +75,6 @@ public class SocketClientUtil {
      *
      * @param socket socket to test
      * @return true if the socket is open and can be read from, otherwise false
-     * @throws IOException
      */
     public static boolean isSocketReadyToRead(Socket socket) throws IOException {
         InputStream in = socket.getInputStream();
@@ -100,7 +97,6 @@ public class SocketClientUtil {
      *
      * @param proxyServer proxy server to open the socket to
      * @return the new socket
-     * @throws IOException
      */
     public static Socket getSocketToProxyServer(HttpProxyServer proxyServer) throws IOException {
         Socket socket = new Socket();


### PR DESCRIPTION
When javadoc is generated for the project, dozens of javadoc warnings are reported, but all of them are related to either missing @param, @return &, @throws tags or their description. As one may expect, they will never be addressed - 99% of the tags would never get a relevant description above simple restating their name and type sans camel case - it may be better to just remove such check entirely. 
Disabling check for missing tags is done in pom.xml. 
Disabling missing tag description is not possible, as missing description is consider invalid tag formatting. This is addressed by removing the offending tags altogether.
