### PR TITLE
Check for either SSLProtocolException or SSLHandshakeException when applying SNI workaround

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -54,6 +54,7 @@ import io.netty.util.concurrent.Future;
 import org.littleshoot.proxy.*;
 import org.littleshoot.proxy.extras.HAProxyMessageEncoder;
 
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
@@ -956,7 +957,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         // sends back a valid certificate for the expected host. we can retry the connection without SNI to allow the proxy
         // to connect to these misconfigured hosts. we should only retry the connection without SNI if the connection
         // failure happened when SNI was enabled, to prevent never-ending connection attempts due to SNI warnings.
-        if (!disableSni && cause instanceof SSLProtocolException) {
+        if (!disableSni && (cause instanceof SSLProtocolException) || (cause instanceof SSLHandshakeException)) {
             // unfortunately java does not expose the specific TLS alert number (112), so we have to look for the
             // unrecognized_name string in the exception's message
             if (cause.getMessage() != null && cause.getMessage().contains("unrecognized_name")) {


### PR DESCRIPTION
Java is more strict than most browsers with respect to the SNI component of a TLS handshake.  In the event that the client sends a server name that the server does not recognize, the server will respond with TLS alert number 112 (`unrecognized_host`).  Most browsers will ignore this alert and proceed with the connection if the server also sends back a valid cert.  However, Java treats this alert as a fatal error and kills the connection.  See related JDK issue here: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7127374

https://github.com/adamfisk/LittleProxy/pull/291 applied a successful workaround for this issue by retrying the handshake with SNI disabled in the event that it receives an `unrecognized_host` response.  Unfortunately this workaround doesn't seem to be working in recent versions of Java (JDK 11 at least) because the SSL implementation isn't throwing `SSLProtocolException` as expected but rather `SSLHandshakeException`.  I've simply added `SSLHandshakeException` to the conditional so that we will properly enter the retry logic.  I've verified that this works locally, although creating a unit test to reproduce this very specific issue would be challenging.

For verification purposes, the host where I'm seeing this issue is `video.limelight.com`.  It produces an `unrecognized_host` alert when setting the server name to `video.limelight.com`:

```
openssl s_client -servername video.limelight.com -connect video.limelight.com:443 -state
CONNECTED(00000003)
SSL_connect:before SSL initialization
SSL_connect:SSLv3/TLS write client hello
SSL3 alert read:warning:unrecognized name
SSL_connect:SSLv3/TLS write client hello
SSL_connect:SSLv3/TLS read server hello
```

Attempting to proxy requests to this host with LittleProxy on Java 11 fails due to the issue I've described above.  With the change in this PR applied, the connection succeeds.