### PR TITLE
Support for WebSockets with MITM in transparent mode

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionPipeHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionPipeHandler.java
@@ -1,0 +1,29 @@
+package org.littleshoot.proxy.impl;
+
+import com.google.common.base.Preconditions;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * A {@link ChannelInboundHandler} that writes all incoming data to the
+ * specified proxy connection.
+ */
+public class ProxyConnectionPipeHandler extends ChannelInboundHandlerAdapter {
+    private final ProxyConnection<?> sink;
+
+    public ProxyConnectionPipeHandler(final ProxyConnection<?> sink) {
+        this.sink = Preconditions.checkNotNull(sink);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        sink.channel.writeAndFlush(msg);
+    }
+    
+    @Override
+    public void channelInactive(final ChannelHandlerContext ctx) {
+        sink.disconnect();
+    }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -60,7 +60,7 @@ public class ProxyUtils {
 
     // Schemes are case-insensitive:
     // http://tools.ietf.org/html/rfc3986#section-3.1
-    private static Pattern HTTP_PREFIX = Pattern.compile("^https?://.*",
+    private static Pattern HTTP_PREFIX = Pattern.compile("^(http|ws)s?://.*",
             Pattern.CASE_INSENSITIVE);
 
     /**
@@ -626,5 +626,18 @@ public class ProxyUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Tests whether the given response indicates that the connection is switching
+     * to the WebSocket protocol.
+     *
+     * @param response the response to check.
+     * @return true if switching to the WebSocket protocol; false otherwise;
+     */
+    public static boolean isSwitchingToWebSocketProtocol(HttpResponse response) {
+        return (response.status() == HttpResponseStatus.SWITCHING_PROTOCOLS)
+                && response.headers().contains(HttpHeaderNames.CONNECTION, HttpHeaderNames.UPGRADE, true)
+                && response.headers().contains(HttpHeaderNames.UPGRADE, "websocket", true);
     }
 }

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
@@ -120,10 +120,10 @@ public class WebSocketClient {
         }
     }
 
-    public void send(final String value) throws IOException {
+    public ChannelFuture send(final String value) {
         lock.readLock().lock();
         try {
-            channel.writeAndFlush(new TextWebSocketFrame(value));   
+            return channel.writeAndFlush(new TextWebSocketFrame(value));
         } finally {
             lock.readLock().unlock();
         }

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
@@ -1,0 +1,198 @@
+package org.littleshoot.proxy.websockets;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.example.http.websocketx.client.WebSocketClientHandler;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+/**
+ * Simple WebSocket client for use in unit tests that sends and receives text
+ * frames.
+ */
+public class WebSocketClient {
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final int MAX_AGGREGATOR_CONTENT_LENGTH = 65536;
+    private static final int MAX_PAYLOAD_FRAME_LENGTH = 1280000;
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketClient.class);
+
+    // According to RFC-6455 (https://tools.ietf.org/html/rfc6455#section-3)
+    // only the ws and wss schemes should be used, but some applications incorrectly
+    // use http/https anyway, so we allow both for testing those edge cases
+    private static final Set<String> SECURE_SCHEMES = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList("wss", "https")));
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final BlockingQueue<String> receivedMessages = new LinkedBlockingQueue<>();
+    private Channel channel;
+    private EventLoopGroup group;
+
+    public void open(final URI uri, final Duration connectTimeout, final Optional<InetSocketAddress> httpProxy) throws TimeoutException {
+        logger.info("{} connecting to {} via proxy {}", getClass().getSimpleName(), uri, httpProxy.map(Object::toString).orElse("(none)"));
+        final boolean isSecure = SECURE_SCHEMES.contains(uri.getScheme());
+        boolean connectionComplete = false;
+        lock.writeLock().lock();
+        try {
+            if (channel != null) {
+                throw new IllegalStateException("Client already open");
+            }
+
+            group = new NioEventLoopGroup();
+
+            final WebSocketFrameReader handler = new WebSocketFrameReader(
+                    WebSocketClientHandshakerFactory.newHandshaker(uri, WebSocketVersion.V13, null, false,
+                            EmptyHttpHeaders.INSTANCE, MAX_PAYLOAD_FRAME_LENGTH, true, false, -1,
+                            httpProxy.isPresent()));
+
+            final Bootstrap bootstrap = new Bootstrap().group(group).channel(NioSocketChannel.class)
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) CONNECT_TIMEOUT.toMillis())
+                    .handler(new WebSocketClientChannelInitializer(handler, uri, httpProxy));
+
+            /*
+             * If using a proxy we connect directly to the proxy for non-secure schemes. For
+             * secure schemes we add a proxy handler that uses HTTP CONNECT, so the
+             * bootstrap just needs to connect as if it's communicating directly with the
+             * origin server.
+             */
+            final ChannelFuture connectFuture;
+            if (httpProxy.isPresent() && !isSecure) {
+                connectFuture = bootstrap.connect(httpProxy.get().getHostString(), httpProxy.get().getPort());
+            } else {
+                connectFuture = bootstrap.connect(uri.getHost(), uri.getPort());
+            }
+
+            if (!connectFuture.awaitUninterruptibly(connectTimeout.toMillis())) {
+                throw new TimeoutException("Connection timed out after " + connectTimeout);
+            }
+            channel = connectFuture.channel();
+            if (!handler.handshakeFuture().awaitUninterruptibly(connectTimeout.toMillis())) {
+                throw new TimeoutException("Handshake timed out after " + connectTimeout);
+            }
+            connectionComplete = true;
+        } finally {
+            if (!connectionComplete) {
+                close();
+            }
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void send(final String value) throws IOException {
+        lock.readLock().lock();
+        try {
+            channel.writeAndFlush(new TextWebSocketFrame(value));   
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public String waitForResponse(final Duration timeout) throws InterruptedException {
+        return Optional.ofNullable(receivedMessages.poll(timeout.toMillis(), TimeUnit.MILLISECONDS))
+                .orElse(null);
+    }
+
+    public void close() {
+        lock.writeLock().lock();
+        try {
+            if (channel == null) {
+                return;
+            }
+            channel.writeAndFlush(new CloseWebSocketFrame());
+            channel.close();
+            group.shutdownGracefully();
+            channel = null;
+            group = null;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private class WebSocketClientChannelInitializer extends ChannelInitializer<SocketChannel> {
+        private final WebSocketClientHandler handler;
+        private final URI uri;
+        private final Optional<InetSocketAddress> httpProxy;
+
+        public WebSocketClientChannelInitializer(final WebSocketClientHandler handler, final URI uri,
+                final Optional<InetSocketAddress> httpProxy) {
+            this.handler = Preconditions.checkNotNull(handler);
+            this.uri = Preconditions.checkNotNull(uri);
+            this.httpProxy = Preconditions.checkNotNull(httpProxy);
+        }
+
+        @Override
+        public void initChannel(final SocketChannel ch) throws Exception {
+            ChannelPipeline pipeline = ch.pipeline();
+            if (SECURE_SCHEMES.contains(uri.getScheme())) {
+                httpProxy.ifPresent(proxyAddress -> pipeline.addFirst(new HttpProxyHandler(proxyAddress)));
+                final SslContext sslContext = SslContextBuilder.forClient()
+                        .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+                final SslHandler sslHandler = sslContext.newHandler(ch.alloc(), uri.getHost(), uri.getPort());
+                sslHandler.setHandshakeTimeoutMillis(CONNECT_TIMEOUT.toMillis());
+                pipeline.addLast("ssl-handler", sslHandler);
+            }
+            pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG));
+            pipeline.addLast("http-codec", new HttpClientCodec());
+            pipeline.addLast("http-aggregator", new HttpObjectAggregator(MAX_AGGREGATOR_CONTENT_LENGTH));
+            pipeline.addLast("ws-handler", handler);
+        }
+    }
+
+    private class WebSocketFrameReader extends WebSocketClientHandler {
+
+        public WebSocketFrameReader(final WebSocketClientHandshaker handshaker) {
+            super(handshaker);
+        }
+
+        @Override
+        public void channelRead0(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+            if (msg instanceof TextWebSocketFrame) {
+                final TextWebSocketFrame textFrame = (TextWebSocketFrame) msg;
+                receivedMessages.offer(textFrame.text());
+            }
+            super.channelRead0(ctx, msg);
+        }
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
@@ -1,0 +1,132 @@
+package org.littleshoot.proxy.websockets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.extras.SelfSignedMitmManager;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketClientServerTest {
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(1);
+    private static final int MAX_CONNECTION_ATTEMPTS = 3;
+    private static final long TEST_TIMEOUT_MILLIS = 10000L;
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketClientServerTest.class);
+    private HttpProxyServer proxy;
+    private WebSocketServer server;
+    private WebSocketClient client;
+
+    @Before
+    public void setUp() {
+        server = new WebSocketServer();
+        client = new WebSocketClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+        if (proxy != null) {
+            proxy.abort();
+            proxy = null;
+        }
+    }
+
+    private void startProxy(final boolean withSsl) {
+        final HttpProxyServerBootstrap bootstrap = DefaultHttpProxyServer.bootstrap().withTransparent(true).withPort(0);
+        if (withSsl) {
+            bootstrap.withManInTheMiddle(new SelfSignedMitmManager());
+        }
+        proxy = bootstrap.start();
+    }
+
+    @Ignore // Only useful for debugging issues with the proxy tests
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void directInsecureConnection() throws Exception {
+        testIntegration(false, false);
+    }
+
+    @Ignore // Only useful for debugging issues with the proxy tests
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void directSecureConnection() throws Exception {
+        testIntegration(true, false);
+    }
+
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void proxiedInsecureConnectionWsScheme() throws Exception {
+        testIntegration(false, true, "ws");
+    }
+    
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void proxiedInsecureConnectionHttpScheme() throws Exception {
+        testIntegration(false, true, "http");
+    }
+
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void proxiedSecureConnectionWssScheme() throws Exception {
+        testIntegration(true, true, "wss");
+    }
+
+    @Test(timeout=TEST_TIMEOUT_MILLIS)
+    public void proxiedSecureConnectionHttpsScheme() throws Exception {
+        testIntegration(true, true, "https");
+    }
+
+    private void testIntegration(final boolean withSsl, final boolean withProxy) throws Exception {
+        testIntegration(withSsl, withProxy, withSsl ? "wss" : "ws");
+    }
+    
+    private void testIntegration(final boolean withSsl, final boolean withProxy, final String scheme) throws Exception {
+        final InetSocketAddress serverAddress = server.start(withSsl);
+        if (withProxy) {
+            startProxy(withSsl);
+        }
+        
+        final URI serverUri = URI.create(scheme + "://" + serverAddress.getHostString() + ":" + serverAddress.getPort()
+                + WebSocketServer.WEBSOCKET_PATH);
+
+        openClient(serverUri, withProxy);
+
+        final String request = "test";
+        client.send(request);
+        final String response = client.waitForResponse(Duration.ofSeconds(5));
+        assertEquals(request.toUpperCase(), response);
+    }
+    
+    private void openClient(final URI uri, final boolean withProxy) throws InterruptedException {
+        final Optional<InetSocketAddress> proxyAddress = Optional.ofNullable(proxy).filter(httpProxy -> withProxy).map(HttpProxyServer::getListenAddress);
+        int connectionAttempt = 0;
+        boolean connected = false;
+        while (!connected && connectionAttempt++ < MAX_CONNECTION_ATTEMPTS) {
+            try {
+                client.open(uri, CONNECT_TIMEOUT, proxyAddress);
+                connected = true;
+            } catch (TimeoutException e) {
+                logger.warn("Connection attempt {} of {} timed out after {}", connectionAttempt, MAX_CONNECTION_ATTEMPTS, CONNECT_TIMEOUT);
+                Thread.sleep(CONNECT_TIMEOUT.toMillis() / 2);
+            }
+        }
+        if (!connected) {
+            fail("Connection timed out after " + MAX_CONNECTION_ATTEMPTS + " attempts");
+        }
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketServer.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketServer.java
@@ -1,0 +1,113 @@
+package org.littleshoot.proxy.websockets;
+
+import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.net.ssl.SSLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.example.http.websocketx.server.WebSocketFrameHandler;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+/**
+ * Simple WebSocket server for use in unit tests that receives text frames and
+ * echoes them back after converting to upper case.
+ */
+public class WebSocketServer {
+    static final String WEBSOCKET_PATH = "/websocket";
+    private static final int MAX_AGGREGATOR_CONTENT_LENGTH = 65536;
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketServer.class);
+    private final Lock lock = new ReentrantLock();
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+    private Channel channel;
+
+    public InetSocketAddress start(final boolean ssl) throws InterruptedException, CertificateException, SSLException {
+        lock.lock();
+        try {
+            if (bossGroup != null) {
+                throw new IllegalStateException("Server already started");
+            }
+
+            final Optional<SslContext> sslCtx;
+            if (ssl) {
+                final SelfSignedCertificate ssc = new SelfSignedCertificate();
+                sslCtx = Optional.of(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build());
+            } else {
+                sslCtx = Optional.empty();
+            }
+
+            bossGroup = new NioEventLoopGroup(1);
+            workerGroup = new NioEventLoopGroup();
+
+            final ServerBootstrap bootstrap = new ServerBootstrap().group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class).handler(new LoggingHandler(LogLevel.DEBUG))
+                    .childHandler(new WebSocketServerInitializer(sslCtx));
+
+            channel = bootstrap.bind("localhost", 0).sync().channel();
+            final InetSocketAddress serverAddress = (InetSocketAddress) channel.localAddress();
+            logger.info("{} listening on {}", getClass().getSimpleName(), serverAddress);
+            return serverAddress;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void stop() throws InterruptedException {
+        lock.lock();
+        try {
+            if (bossGroup == null) {
+                return;
+            }
+            channel.close().sync();
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+            channel = null;
+            bossGroup = null;
+            workerGroup = null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private class WebSocketServerInitializer extends ChannelInitializer<SocketChannel> {
+        private final Optional<SslContext> sslCtx;
+
+        public WebSocketServerInitializer(final Optional<SslContext> sslCtx) {
+            this.sslCtx = Preconditions.checkNotNull(sslCtx);
+        }
+
+        @Override
+        public void initChannel(final SocketChannel channel) throws Exception {
+            final ChannelPipeline pipeline = channel.pipeline();
+            sslCtx.map(ctx -> ctx.newHandler(channel.alloc()))
+                    .ifPresent(handler -> pipeline.addLast("ssl", handler));
+            pipeline.addLast("http-codec", new HttpServerCodec());
+            pipeline.addLast("http-aggregator", new HttpObjectAggregator(MAX_AGGREGATOR_CONTENT_LENGTH));
+            pipeline.addLast("ws-protocol", new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
+            pipeline.addLast("ws-frame", new WebSocketFrameHandler());
+        }
+    }
+}


### PR DESCRIPTION
Currently LittleProxy has limited support for WebSockets ([RFC 6455](https://tools.ietf.org/html/rfc6455)).  While investigating the problems with WebSockets I found that LittleProxy actually _does_ support WebSockets in one configuration: LittleProxy has to be operating in transparent mode _without_ MITM enabled.  This PR allows WebSockets to work in transparent mode _with_ MITM enabled.  Transparent mode is still required because the WebSocket handshake requires the `Connection: Upgrade` and `Upgrade: websocket` headers to be passed end-to-end between the client and server.  However, these headers are hop-by-hop headers, so without transparent mode they are removed by the proxy, which I believe is the correct behavior.

The actual code changes to the proxy are fairly minor.  When we see HTTP 101 (switching protocols) response from the server with `Connection: Upgrade` and `Upgrade: websocket` headers, we simply remove all HTTP handlers from the channel pipeline and replace the main proxy handler with a simple handler that just pipes the raw bytes back and forth between the proxy client and the server.

Adding unit tests for this functionality was a little tricky.  I had to implement a WebSocket client and server plus a unit test that combines those two with a LittleProxy instance.  Whenever possible I used the classes from the Netty `io.netty.example.http.websocketx` and `io.netty.handler.codec.http.websocketx` packages to reduce the amount of code that had to be written for the tests, but the majority of code added in this PR was probably for the tests.