### PR TITLE
Mark threads as daemon threads

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/CategorizedThreadFactory.java
+++ b/src/main/java/org/littleshoot/proxy/impl/CategorizedThreadFactory.java
@@ -39,6 +39,7 @@ public class CategorizedThreadFactory implements ThreadFactory {
     public Thread newThread(Runnable r) {
         Thread t = new Thread(r, name + "-" + uniqueServerGroupId + "-" + category + "-" + threadCount.getAndIncrement());
 
+        t.setDaemon(true);
         t.setUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER);
 
         return t;


### PR DESCRIPTION
Threads should be daemon (not user, which is the default) threads so the JVM exits as expected when all other threads stop.