### PR TITLE
Stop the proxy if it fails to start

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -520,6 +520,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 
         Throwable cause = future.cause();
         if (cause != null) {
+            abort();
             throw new RuntimeException(cause);
         }
 


### PR DESCRIPTION
During startup, the proxy initializes thread pools and starts threads. If the proxy fails to start (such as if the port it tries to run on is already in use resulting in a `BindException`), those threads need to be stopped; calling `abort()` shuts down those threads.