### PR TITLE
catch VerifyError under Android when checking for UDT

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -540,7 +540,7 @@ public class ProxyUtils {
     public static boolean isUdtAvailable() {
         try {
             return NioUdtProvider.BYTE_PROVIDER != null;
-        } catch (NoClassDefFoundError e) {
+        } catch (Throwable e) {
             return false;
         }
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -540,7 +540,10 @@ public class ProxyUtils {
     public static boolean isUdtAvailable() {
         try {
             return NioUdtProvider.BYTE_PROVIDER != null;
-        } catch (Throwable e) {
+        } catch (NoClassDefFoundError e) {
+            return false;
+            // necessary for Android which throws VerifyError if the field BYTE_PROVIDER is accessed of the unavailable class
+        } catch (VerifyError e) {
             return false;
         }
     }


### PR DESCRIPTION
Under Android the check does not work when excluding the UDT dependencies. A [VerifyError](https://developer.android.com/reference/java/lang/VerifyError) is thrown because the class `NioUdtProvider` does not exist and the field `BYTE_PROVIDER` cannot be accessed.