### PR TITLE
Fix NoSuchElementException when switching protocols to WebSocket

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -312,18 +312,10 @@ abstract class ProxyConnection<I extends HttpObject> extends
         protected Future execute() {
             try {
                 ChannelPipeline pipeline = ctx.pipeline();
-                if (pipeline.get("encoder") != null) {
-                    pipeline.remove("encoder");
-                }
-                if (pipeline.get("responseWrittenMonitor") != null) {
-                    pipeline.remove("responseWrittenMonitor");
-                }
-                if (pipeline.get("decoder") != null) {
-                    pipeline.remove("decoder");
-                }
-                if (pipeline.get("requestReadMonitor") != null) {
-                    pipeline.remove("requestReadMonitor");
-                }
+                removeHandlerIfPresent(pipeline, "encoder");
+                removeHandlerIfPresent(pipeline, "responseWrittenMonitor");
+                removeHandlerIfPresent(pipeline, "decoder");
+                removeHandlerIfPresent(pipeline, "requestReadMonitor");
                 tunneling = true;
                 return channel.newSucceededFuture();
             } catch (Throwable t) {
@@ -431,6 +423,20 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * processing on the {@link Channel}.
      */
     protected void exceptionCaught(Throwable cause) {
+    }
+    
+    /**
+     * Removes the handler with the given name if it is present in the pipeline.
+     * @param pipeline the pipeline from which to remove the handler.
+     * @param handlerName the name of the handler to remove.
+     * @return true if the handler was found and removed; false otherwise.
+     */
+    protected boolean removeHandlerIfPresent(ChannelPipeline pipeline, String handlerName) {
+        if (pipeline.get(handlerName) != null) {
+            pipeline.remove(handlerName);
+            return true;
+        }
+        return false;
     }
 
     /* *************************************************************************


### PR DESCRIPTION
Occasionally we're seeing `NoSuchElementException` when we try to remove the HTTP handlers when switching protocols for a WebSocket connection.  Example stack trace:

```
java.util.NoSuchElementException: handler
at io.netty.channel.DefaultChannelPipeline.getContextOrDie (DefaultChannelPipeline.java:1073)
at io.netty.channel.DefaultChannelPipeline.replace (DefaultChannelPipeline.java:515)
at org.littleshoot.proxy.impl.ClientToProxyConnection.switchToWebSocketProtocol (ClientToProxyConnection.java:478)
at org.littleshoot.proxy.impl.ClientToProxyConnection.respond (ClientToProxyConnection.java:468)
at org.littleshoot.proxy.impl.ProxyToServerConnection.respondWith (ProxyToServerConnection.java:560)
at org.littleshoot.proxy.impl.ProxyToServerConnection.readHTTPInitial (ProxyToServerConnection.java:280)
at org.littleshoot.proxy.impl.ProxyToServerConnection.readHTTPInitial (ProxyToServerConnection.java:108)
at org.littleshoot.proxy.impl.ProxyConnection.readHTTP (ProxyConnection.java:140)
at org.littleshoot.proxy.impl.ProxyConnection.read (ProxyConnection.java:120)
at org.littleshoot.proxy.impl.ProxyToServerConnection.read (ProxyToServerConnection.java:250)
at org.littleshoot.proxy.impl.ProxyConnection.channelRead0 (ProxyConnection.java:556)
```

This change just adds some checks to ensure that the handler exists before we try to remove it.  I also tried to refactor some existing similar code to generalize it a little better.