### PR TITLE
Prevent NullPointerException in ProxyUtils::isHEAD

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -313,7 +313,7 @@ public class ProxyUtils {
      * @return true if request is a HEAD, otherwise false
      */
     public static boolean isHEAD(HttpRequest httpRequest) {
-        return HttpMethod.HEAD.equals(httpRequest.method());
+        return httpRequest != null && HttpMethod.HEAD.equals(httpRequest.method());
     }
 
     private static boolean checkTrueOrFalse(final String val,


### PR DESCRIPTION
We see fairly frequent NPEs in `ProxyUtils::isHEAD`, such as this stack trace:

```
java.lang.NullPointerException: null
at org.littleshoot.proxy.impl.ProxyUtils.isHEAD (ProxyUtils.java:316)
at org.littleshoot.proxy.impl.ClientToProxyConnection.respond (ClientToProxyConnection.java:434)
at org.littleshoot.proxy.impl.ProxyToServerConnection.respondWith (ProxyToServerConnection.java:560)
at org.littleshoot.proxy.impl.ProxyToServerConnection.readHTTPInitial (ProxyToServerConnection.java:280)
at org.littleshoot.proxy.impl.ProxyToServerConnection.readHTTPInitial (ProxyToServerConnection.java:108)
at org.littleshoot.proxy.impl.ProxyConnection.readHTTP (ProxyConnection.java:140)
at org.littleshoot.proxy.impl.ProxyConnection.read (ProxyConnection.java:120)
at org.littleshoot.proxy.impl.ProxyToServerConnection.read (ProxyToServerConnection.java:250)
at org.littleshoot.proxy.impl.ProxyConnection.channelRead0 (ProxyConnection.java:550)
```

This change just adds a `null` guard in that method.