### PR TITLE
Use single Hamcrest dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,14 +173,7 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1:
> After a long hiatus without releases, this version simplifies the packaging of Hamcrest into a single jar: hamcrest-2.1.jar.