### PR TITLE
Improve logging performance

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - 2.0.6
   - Use single Hamcrest dependency in tests
+  - Improve logging performance
 
 - 2.0.5
   - Bumped jetty-server from 9.4.34.v20201102 to 9.4.41.v20210516.
@@ -17,11 +18,11 @@
   - Upgrade guava to 30.1
   - Threads are now set as daemon (not user, which is the default) threads so the JVM exits as expected when all other threads stop.
   - Close thread pool if proxy fails to start
-  
+
 - 2.0.2
   - Support for WebSockets with MITM in transparent mode
   - Support for per request conditional MITM
-  
+
 - 2.0.1
   - Removed beta tag from version
   - Updated various dependency versions

--- a/src/main/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSource.java
+++ b/src/main/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSource.java
@@ -179,11 +179,10 @@ public class SelfSignedSslEngineSource implements SslEngineSource {
             }
             String dataAsString = new String(data);
 
-            LOG.info("Completed native call: '{}'\nResponse: '" + dataAsString + "'",
-                    Arrays.asList(commands));
+            LOG.info("Completed native call: '{}'\nResponse: '{}'", Arrays.asList(commands), dataAsString);
             return dataAsString;
         } catch (final IOException e) {
-            LOG.error("Error running commands: " + Arrays.asList(commands), e);
+            LOG.error("Error running commands: {}", Arrays.asList(commands), e);
             return "";
         }
     }

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -451,7 +451,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
      * @param graceful when false, attempts to shutdown all channels immediately and ignores any channel-closing exceptions
      */
     protected void closeAllChannels(boolean graceful) {
-        LOG.info("Closing all channels " + (graceful ? "(graceful)" : "(non-graceful)"));
+        LOG.info("Closing all channels {}", graceful ? "(graceful)" : "(non-graceful)");
 
         ChannelGroupFuture future = allChannels.close();
 
@@ -477,7 +477,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
 
     private HttpProxyServer start() {
         if (!serverGroup.isStopped()) {
-            LOG.info("Starting proxy at address: " + this.requestedAddress);
+            LOG.info("Starting proxy at address: {}", this.requestedAddress);
 
             serverGroup.registerProxyServer(this);
 
@@ -533,7 +533,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         this.boundAddress = ((InetSocketAddress) future.channel().localAddress());
-        LOG.info("Proxy started at address: " + this.boundAddress);
+        LOG.info("Proxy started at address: {}", this.boundAddress);
 
         Runtime.getRuntime().addShutdownHook(jvmShutdownHook);
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -209,7 +209,7 @@ public class ServerGroup {
             return;
         }
 
-        log.info("Shutting down server group event loops " + (graceful ? "(graceful)" : "(non-graceful)"));
+        log.info("Shutting down server group event loops {}", graceful ? "(graceful)" : "(non-graceful)");
 
         // loop through all event loops managed by this server group. this includes acceptor and worker event loops
         // for both TCP and UDP transport protocols.


### PR DESCRIPTION
Non-constant concatenations are evaluated at runtime even
when the logging message is not logged; this can negatively
impact performance. It is recommended to use a parameterized
log message instead, which will not be evaluated when logging
is disabled.