### PR TITLE
Bump log4j-core from 2.16.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
See: https://www.cve.org/CVERecord?id=CVE-2021-44832

Closes: https://github.com/mrog/LittleProxy/issues/75