### PR TITLE
mark slow tests with an annotation @Category(SlowTest.class)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                          <excludes>
-                            <!-- Slow tests: -->
-                            <exclude>org/littleshoot/proxy/websockets/*</exclude>
-                            <exclude>org/littleshoot/proxy/KeepAliveTest*</exclude>
-                            <exclude>org/littleshoot/proxy/IdlingProxyTest*</exclude>
-                            <exclude>org/littleshoot/proxy/ThrottlingTest*</exclude>
-                          </excludes>
+                          <excludedGroups>org.littleshoot.proxy.SlowTest</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
@@ -1,12 +1,14 @@
 package org.littleshoot.proxy;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests just a single basic proxy.
  */
+@Category(SlowTest.class)
 public class IdlingProxyTest extends AbstractProxyTest {
     @Override
     protected void setUp() {

--- a/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
+++ b/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
@@ -1,9 +1,16 @@
 package org.littleshoot.proxy;
 
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.test.SocketClientUtil;
 import org.mockserver.integration.ClientAndServer;
@@ -15,14 +22,20 @@ import java.net.Socket;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 /**
  * This class tests the proxy's keep alive/connection closure behavior.
  */
+@Category(SlowTest.class)
 public class KeepAliveTest {
     private HttpProxyServer proxyServer;
 

--- a/src/test/java/org/littleshoot/proxy/SlowTest.java
+++ b/src/test/java/org/littleshoot/proxy/SlowTest.java
@@ -1,0 +1,4 @@
+package org.littleshoot.proxy;
+
+public interface SlowTest {
+}

--- a/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
+++ b/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runners.MethodSorters;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
@@ -22,6 +23,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@Category(SlowTest.class)
 @FixMethodOrder(MethodSorters.JVM)
 public class ThrottlingTest {
     private static final int LARGE_DATA_SIZE = 200000;

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
@@ -14,13 +14,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.SlowTest;
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(SlowTest.class)
 public class WebSocketClientServerTest {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(5);


### PR DESCRIPTION
so we don't need to list them explicitly in pom.xml