### PR TITLE
#115 reverted to maven-shade-plugin 3.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ You can embed LittleProxy in your own projects through Maven with the following:
     <dependency>
         <groupId>xyz.rogfam</groupId>
         <artifactId>littleproxy</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </dependency>
 ```
 
 Or with Gradle like this
 
-`compile "xyz.rogfam:littleproxy:2.0.8"`
+`compile "xyz.rogfam:littleproxy:2.0.9"`
 
 Once you've included LittleProxy, you can start the server with the following:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+- 2.0.9
+  - #115 reverted to maven-shade-plugin 3.2.4 (because 3.3.0 generated artifact without compile/runtime dependencies)
+
 - 2.0.8
   - #26 fixed TLS 1.3 handshake bug  --  thanks Dan Powell for PR https://github.com/LittleProxy/LittleProxy/pull/26
   - Bumped log4j-core from 2.17.0 to 2.17.2

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>xyz.rogfam</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
@@ -542,7 +542,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
(because 3.3.0 generated artifact without compile/runtime dependencies)

fixes https://github.com/LittleProxy/LittleProxy/issues/115

I had to rollback naven-shade-plugin to version 3.2.4 because version 3.3.0 has a critical bug https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419 which broke our dependencies.