### PR TITLE
HTTP CONNECT can't be Keep-Alive once connected successfully

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -536,7 +536,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             LOG.debug("Responding with CONNECT successful");
             HttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1,
                     CONNECTION_ESTABLISHED);
-            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
             ProxyUtils.addVia(response, proxyServer.getProxyAlias());
             return writeToChannel(response);
         }


### PR DESCRIPTION
It is technically wrong to expect an HTTP connection that uses the CONNECT verb and becomes connected to ever be reused via Keep Alive.

Once the HTTP CONNECT is successful, the client has no way to give back to the proxy another request: it is by then connected to the remote end (or a MITM'ed flavor of it) and upon the remote end disconnection, the HTTP connection has to be disconnected as there is no other signal that can be given from the Proxy back to the Client to signify the remote end has disconnected and control is now back to the Proxy.