### PR TITLE
Revert "Bump netty.version from 4.1.82.Final to 4.1.84.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.1.84.Final</netty.version>
+        <netty.version>4.1.82.Final</netty.version>
         <slf4j.version>2.0.3</slf4j.version>
         <java.version>1.8</java.version>
     </properties>


### PR DESCRIPTION
This reverts commit fd3955ec39fc2897a3fd671557d50ea2ac12208b.
Changes in latest version of netty (https://github.com/netty/netty/pull/12760) cause existing unit tests to fail. Reverting until the correct logic is being tested in littleProxy.