### PR TITLE
Export certificate to generated by `SelfSignedMitmManager` KeyStore directory

### DIFF
--- a/src/test/java/org/littleshoot/proxy/SelfSignedGeneratedSslEngineChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/SelfSignedGeneratedSslEngineChainedProxyTest.java
@@ -34,6 +34,12 @@ public class SelfSignedGeneratedSslEngineChainedProxyTest extends BaseChainedPro
         assertTrue(keyStoreFile.exists());
     }
 
+    @Test
+    public void testCertExportedToKeyStoreDirectory() {
+        File certFile = temporaryFolder.getRoot().toPath().resolve("./certs/littleproxy_cert").toFile();
+        assertTrue(certFile.exists());
+    }
+
     @Override
     protected HttpProxyServerBootstrap upstreamProxy() {
         return super.upstreamProxy()


### PR DESCRIPTION
This is a continuation of #184

`SelfSignedMitmManager` created KeyStore file at the provided path (fixed by #184) and then exported certificate to another directory (depending on the execution way, usually it was a root directory of the running process).
This change fixes the behavior: now certificate is exported to the same directory where KeyStore file is created.