### PR TITLE
CI: disable fail-fast in build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
This option is needed to be disabled to collect information on failures from all platforms. Otherwise the first failure cancels executions at all other platforms.