### PR TITLE
On proxy connection unregister, unregister downstream channels

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -445,6 +445,14 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         allChannels.add(channel);
     }
 
+    protected void unregisterChannel(Channel channel) {
+        if (channel.isOpen()) {
+            // Unlikely to happen, but just in case...
+            channel.close();
+        }
+        allChannels.remove(channel);
+    }
+
     /**
      * Closes all channels opened by this proxy server.
      *

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -567,6 +567,12 @@ abstract class ProxyConnection<I extends HttpObject> extends
         }
     }
 
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        this.proxyServer.unregisterChannel(ctx.channel());
+        super.channelUnregistered(ctx);
+    }
+
     /**
      * Only once the Netty Channel is active to we recognize the ProxyConnection
      * as connected.


### PR DESCRIPTION
When the proxy connection's channel is unregistered, also unregister all of its associated channels to avoid leaking memory.

Extracted from the LittleProxy fork at https://github.com/verygoodsecurity/LittleProxy/commit/6adc7fa9a1ae224606871096302835ac5f325112