### PR TITLE
Fixing leak

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -239,6 +239,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * </p>
      */
     private ConnectionState doReadHTTPInitial(HttpRequest httpRequest) {
+        resetCurrentRequest();
         // Make a copy of the original request
         this.currentRequest = copy(httpRequest);
 


### PR DESCRIPTION
Fixes #131 

This PR releases current request before copying new request in it. Without releasing first, I get exception 

```
[] - [ERROR] 22-06-2022 23:46:33.393 - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
Created at:
	io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:403)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:188)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:179)
	io.netty.buffer.CompositeByteBuf.allocBuffer(CompositeByteBuf.java:1879)
	io.netty.buffer.CompositeByteBuf.copy(CompositeByteBuf.java:1524)
	io.netty.buffer.AbstractByteBuf.copy(AbstractByteBuf.java:1194)
	io.netty.handler.codec.http.HttpObjectAggregator$AggregatedFullHttpRequest.copy(HttpObjectAggregator.java:404)
	org.littleshoot.proxy.impl.ClientToProxyConnection.copy(ClientToProxyConnection.java:1073)
	org.littleshoot.proxy.impl.ClientToProxyConnection.doReadHTTPInitial(ClientToProxyConnection.java:243)
	org.littleshoot.proxy.impl.ClientToProxyConnection.readHTTPInitial(ClientToProxyConnection.java:222)
	org.littleshoot.proxy.impl.ClientToProxyConnection.readHTTPInitial(ClientToProxyConnection.java:86)
	org.littleshoot.proxy.impl.ProxyConnection.readHTTP(ProxyConnection.java:140)
```