### PR TITLE
Always use a new connection for websockets

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -303,6 +303,11 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                     "Not reusing existing ProxyToServerConnection because request is a CONNECT for: {}",
                     serverHostAndPort);
             newConnectionRequired = true;
+        } else if (ProxyUtils.isSwitchingToWebSocketProtocol(httpRequest)) {
+            LOG.debug(
+                    "Not reusing existing ProxyToServerConnection because request is an upgrade to websocket for: {}",
+                    serverHostAndPort);
+            newConnectionRequired = true;
         } else if (currentServerConnection == null) {
             LOG.debug("Didn't find existing ProxyToServerConnection for: {}",
                     serverHostAndPort);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -643,4 +643,16 @@ public class ProxyUtils {
                 && response.headers().contains(HttpHeaderNames.CONNECTION, HttpHeaderNames.UPGRADE, true)
                 && response.headers().contains(HttpHeaderNames.UPGRADE, "websocket", true);
     }
+
+    /**
+     * Tests whether the given request indicates that the connection is switching
+     * to the WebSocket protocol.
+     *
+     * @param request the request to check.
+     * @return true if switching to the WebSocket protocol; false otherwise;
+     */
+    public static boolean isSwitchingToWebSocketProtocol(HttpRequest request) {
+        return request.headers().contains(HttpHeaderNames.CONNECTION, HttpHeaderNames.UPGRADE, true)
+                && request.headers().contains(HttpHeaderNames.UPGRADE, "websocket", true);
+    }
 }


### PR DESCRIPTION
Don't try to reuse an existing connection when servicing a request to upgrade a connection to websockets.

Websockets connections can't be reused. An attempt to reuse a websockets connection for HTTP will fail.

Fixes an issue where a websockets connection is attempted to be reused resulting in garbage and failures when that connection is reused.