### PR TITLE
Fix Websocket race condition while protocol switching

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -4,6 +4,7 @@ import com.google.common.io.BaseEncoding;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
@@ -1388,8 +1389,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * and using the empty buffer's future instead to handle any operations we
      * need to when responses are fully written back to clients.
      */
-    private void writeEmptyBuffer() {
-        write(Unpooled.EMPTY_BUFFER);
+    private ChannelFuture writeEmptyBuffer() {
+        return write(Unpooled.EMPTY_BUFFER);
     }
 
     public boolean isMitming() {

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -303,11 +303,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                     "Not reusing existing ProxyToServerConnection because request is a CONNECT for: {}",
                     serverHostAndPort);
             newConnectionRequired = true;
-        } else if (ProxyUtils.isSwitchingToWebSocketProtocol(httpRequest)) {
-            LOG.debug(
-                    "Not reusing existing ProxyToServerConnection because request is an upgrade to websocket for: {}",
-                    serverHostAndPort);
-            newConnectionRequired = true;
         } else if (currentServerConnection == null) {
             LOG.debug("Didn't find existing ProxyToServerConnection for: {}",
                     serverHostAndPort);

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -490,6 +490,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             return;
         }
 
+        if (isSwitchingToWebSocketProtocol) {
+            serverConnection.switchToWebSocketProtocol();
+        }
         write(filteredhttpObject).addListener(l -> {
 
 	        if (ProxyUtils.isLastChunk(filteredhttpObject)) {
@@ -519,7 +522,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                     new ProxyConnectionPipeHandler(serverConnection));
         }
         orderedHandlersToRemove.forEach(this::removeHandlerIfPresent);
-        serverConnection.switchToWebSocketProtocol();
     }
 
     /* *************************************************************************

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -71,7 +71,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
     protected volatile Channel channel;
 
     private volatile ConnectionState currentState;
-    private volatile boolean tunneling = false;
+    protected volatile boolean tunneling = false;
     protected volatile long lastReadTime = 0;
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -255,7 +255,11 @@ abstract class ProxyConnection<I extends HttpObject> extends
     }
 
     protected ChannelFuture writeToChannel(final Object msg) {
-        return channel.writeAndFlush(msg);
+        return channel.writeAndFlush(msg).addListener(l-> {
+            if (!l.isSuccess()) {
+                LOG.debug("writeToChannel failed sending message {}", msg, l.cause());
+            }
+        });
     }
 
     /* *************************************************************************

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -1218,6 +1218,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     new ProxyConnectionPipeHandler(clientConnection));
         }
         orderedHandlersToRemove.forEach(this::removeHandlerIfPresent);
+        tunneling = true;
     }
 
     /* *************************************************************************


### PR DESCRIPTION
After the "HTTP/1.1 101 Switching Protocols" message is sent to the
client, the pipeline needs to be reconfigured. The pipeline cannot be
reconfigured until after the message is written - if it's reconfigured
before the message is written, the pipeline won't have the "encoder"
necessary to encode the `DefaultHttpResponse` to a byte buffer, resulting
in this exception:
```
io.netty.handler.codec.UnsupportedMessageTypeException: io.netty.handler.codec.http.DefaultHttpResponse (expected: io.netty.buffer.ByteBuf)
        at io.netty.handler.ssl.SslHandler.write(SslHandler.java:772)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
        at io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113)
        at org.littleshoot.proxy.impl.ProxyConnection$BytesWrittenMonitor.write(ProxyConnection.java:738)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
        at io.netty.handler.timeout.IdleStateHandler.write(IdleStateHandler.java:302)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
        at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1247)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at java.base/java.lang.Thread.run(Thread.java:1623)
```

Netty performs write asynchronously, so calling `write` then
reconfiguring the pipeline may result in the pipeline being reconfigured
before the the message is actually written - a classic race condition.
To guarantee the pipeline is reconfigured after the message is written,
a listener that reconfigures the pipeline must be attached to the
`ChannelFuture` returned by the `write` method.
