### PR TITLE
Enhancement: Expose proxy to server ctx to access client address

### DIFF
--- a/src/main/java/org/littleshoot/proxy/FullFlowContext.java
+++ b/src/main/java/org/littleshoot/proxy/FullFlowContext.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.littleshoot.proxy.impl.ClientToProxyConnection;
 import org.littleshoot.proxy.impl.ProxyToServerConnection;
 
@@ -10,12 +11,14 @@ import org.littleshoot.proxy.impl.ProxyToServerConnection;
 public class FullFlowContext extends FlowContext {
     private final String serverHostAndPort;
     private final ChainedProxy chainedProxy;
+    private final ChannelHandlerContext ctx;
 
     public FullFlowContext(ClientToProxyConnection clientConnection,
             ProxyToServerConnection serverConnection) {
         super(clientConnection);
         serverHostAndPort = serverConnection.getServerHostAndPort();
         chainedProxy = serverConnection.getChainedProxy();
+        this.ctx = serverConnection.getContext();
     }
 
     /**
@@ -30,6 +33,13 @@ public class FullFlowContext extends FlowContext {
      */
     public ChainedProxy getChainedProxy() {
         return chainedProxy;
+    }
+
+    /**
+     * The proxy to server channel context.
+     */
+    public ChannelHandlerContext getProxyToServerContext() {
+        return ctx;
     }
 
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -816,4 +816,12 @@ abstract class ProxyConnection<I extends HttpObject> extends
         protected abstract void responseWritten(HttpResponse httpResponse);
     }
 
+    /**
+     * Gets the channel handler context
+     * @return the channel handler context
+     */
+    public ChannelHandlerContext getContext() {
+        return ctx;
+    }
+
 }


### PR DESCRIPTION
Our project needs to know the client address (the outbound address) when bytesSentToServer. In this PR, I am exposing the ChannelHandlerContext so that we can get the client information 