### PR TITLE
registerChannel synchronously during start

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -552,6 +552,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             abort();
             throw new RuntimeException(cause);
         }
+
         Channel serverChannel = future.channel();
         registerChannel(serverChannel);
         boundAddress = (InetSocketAddress) serverChannel.localAddress();


### PR DESCRIPTION
We have noticed a problem if proxy is stopped quickly after starting.
The "main" thread first calls `start()` and then `stop()`, but listener runs in another thread and by the moment `stop` is executed - the channel is not added to the group and stays alive forever.