### PR TITLE
remove most Guava usages

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,6 +5,7 @@
     <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="Convert2MethodRef" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EmptyMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HttpUrlsUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="JavadocBlankLines" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1,6 +1,5 @@
 package org.littleshoot.proxy.impl;
 
-import com.google.common.io.BaseEncoding;
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -48,6 +47,7 @@ import java.net.UnknownHostException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1026,12 +1026,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         String fullValue = values.iterator().next();
         String value = StringUtils.substringAfter(fullValue, "Basic ").trim();
 
-        byte[] decodedValue = BaseEncoding.base64().decode(value);
+        String decodedValue = new String(Base64.getDecoder().decode(value), UTF_8);
 
-        String decodedString = new String(decodedValue, UTF_8);
-
-        String userName = StringUtils.substringBefore(decodedString, ":");
-        String password = StringUtils.substringAfter(decodedString, ":");
+        String userName = StringUtils.substringBefore(decodedValue, ":");
+        String password = StringUtils.substringAfter(decodedValue, ":");
         if (!authenticator.authenticate(userName, password)) {
             writeAuthenticationRequired(authenticator.getRealm());
             return true;

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionPipeHandler.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionPipeHandler.java
@@ -1,10 +1,10 @@
 package org.littleshoot.proxy.impl;
 
-import com.google.common.base.Preconditions;
-
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ChannelInboundHandler} that writes all incoming data to the
@@ -14,14 +14,14 @@ public class ProxyConnectionPipeHandler extends ChannelInboundHandlerAdapter {
     private final ProxyConnection<?> sink;
 
     public ProxyConnectionPipeHandler(final ProxyConnection<?> sink) {
-        this.sink = Preconditions.checkNotNull(sink);
+        this.sink = requireNonNull(sink, "sink cannot be null");
     }
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
         sink.channel.writeAndFlush(msg);
     }
-    
+
     @Override
     public void channelInactive(final ChannelHandlerContext ctx) {
         sink.disconnect();

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyThreadPools.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyThreadPools.java
@@ -1,6 +1,5 @@
 package org.littleshoot.proxy.impl;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 
@@ -47,7 +46,7 @@ public class ProxyThreadPools {
      * Returns all event loops (acceptor and worker thread pools) in this pool.
      */
     public List<EventLoopGroup> getAllEventLoops() {
-        return ImmutableList.of(clientToProxyAcceptorPool, clientToProxyWorkerPool, proxyToServerWorkerPool);
+        return List.of(clientToProxyAcceptorPool, clientToProxyWorkerPool, proxyToServerWorkerPool);
     }
 
     public NioEventLoopGroup getClientToProxyAcceptorPool() {

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClient.java
@@ -1,6 +1,5 @@
 package org.littleshoot.proxy.websockets;
 
-import com.google.common.base.Preconditions;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -42,6 +41,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -150,9 +150,9 @@ public class WebSocketClient {
 
         public WebSocketClientChannelInitializer(final WebSocketClientHandler handler, final URI uri,
                 final Optional<InetSocketAddress> httpProxy) {
-            this.handler = Preconditions.checkNotNull(handler);
-            this.uri = Preconditions.checkNotNull(uri);
-            this.httpProxy = Preconditions.checkNotNull(httpProxy);
+            this.handler = requireNonNull(handler);
+            this.uri = requireNonNull(uri);
+            this.httpProxy = requireNonNull(httpProxy);
         }
 
         @Override

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketServer.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketServer.java
@@ -1,20 +1,5 @@
 package org.littleshoot.proxy.websockets;
 
-import java.net.InetSocketAddress;
-import java.security.cert.CertificateException;
-import java.time.Duration;
-import java.util.Optional;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import javax.net.ssl.SSLException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -33,6 +18,19 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Simple WebSocket server for use in unit tests that receives text frames and
@@ -103,7 +101,7 @@ public class WebSocketServer {
         private final Optional<SslContext> sslCtx;
 
         public WebSocketServerInitializer(final Optional<SslContext> sslCtx) {
-            this.sslCtx = Preconditions.checkNotNull(sslCtx);
+            this.sslCtx = requireNonNull(sslCtx);
         }
 
         @Override


### PR DESCRIPTION
nowadays, Java standard method `List.of` does the same job as `ImmutableList.of`.

But two methods are not yet easily replaceable:
1. `HostAndPort.fromString`
2. `ByteStreams.toByteArray`