### PR TITLE
fix LittleProxy is not starting with jdk higher than jdk 11.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - 2.5.1 (under construction, https://github.com/LittleProxy/LittleProxy/milestone/49)
   - TBD
+  - fix LittleProxy is not starting with jdk higher than jdk 11. (#669)
 
 - 2.5.0 (19.12.2025, https://github.com/LittleProxy/LittleProxy/milestone/48?closed=1)
   - enhance documentation with run.bash script options (#659) by Charles Lescot

--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.littleshoot.proxy.Launcher</Main-Class>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">


### PR DESCRIPTION
if i execute `run.bash` with a jdk higher than 11 (tested with 17 and 24), it fails with this kind of message : 

```java
Exception in thread "main" java.util.ServiceConfigurationError: java.net.spi.InetAddressResolverProvider: Provider org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider not found
        at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:559)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1090)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1099)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
        at java.base/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
        at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
        at java.base/java.util.ServiceLoader.findFirst(ServiceLoader.java:1659)
        at java.base/java.net.InetAddress.loadResolver(InetAddress.java:487)
        at java.base/java.net.InetAddress.resolver(InetAddress.java:467)
        at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1695)
        at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:1056)
        at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1687)
        at java.base/java.net.InetAddress.getLocalHost(InetAddress.java:1780)
        at org.littleshoot.proxy.impl.ProxyUtils.getHostName(ProxyUtils.java:472)
        at org.littleshoot.proxy.impl.DefaultHttpProxyServer.<init>(DefaultHttpProxyServer.java:315)
        at org.littleshoot.proxy.impl.DefaultHttpProxyServer$DefaultHttpProxyServerBootstrap.build(DefaultHttpProxyServer.java:1054)
        at org.littleshoot.proxy.impl.DefaultHttpProxyServer$DefaultHttpProxyServerBootstrap.start(DefaultHttpProxyServer.java:1039)
        at org.littleshoot.proxy.Launcher.main(Launcher.java:336)
Java process exited abnormally
```

A multirelease jar need to be done, with a little addition in the `maven-shade-plugin` transformers block (`Multi-Release` set to `true` in the manifest).

After this change, jdk 11, jdk 17 and jdk 24  (and other versions higher than 11) will run LittleProxy without the "org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider not found" error.