### PR TITLE
Fix slow resolution of hostname

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/Hostname.java
+++ b/src/main/java/org/littleshoot/proxy/impl/Hostname.java
@@ -1,0 +1,89 @@
+package org.littleshoot.proxy.impl;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+class Hostname {
+  private static final Logger LOG = LoggerFactory.getLogger(Hostname.class);
+
+  private static volatile String hostname;
+
+  @Nullable
+  static String getHostName() {
+    if (hostname == null) {
+      hostname = resolveHostName();
+    }
+    return hostname;
+  }
+
+  @Nullable
+  private static String resolveHostName() {
+    long startTime = nanoTime();
+    String hostName = byAllMeans(
+      env("HOSTNAME"), // Most OSs
+      env("COMPUTERNAME"), // Windows
+      Hostname::executeHostname,
+      Hostname::getLocalHost
+    );
+    long duration = NANOSECONDS.toMillis(nanoTime() - startTime);
+    LOG.info("Resolved local machine's hostname \"{}\" in {} ms.", hostName, duration);
+    return hostName;
+  }
+
+  @Nullable
+  @SafeVarargs
+  private static String byAllMeans(SupplierEx<String>... means) {
+    return Stream.of(means)
+      .map(mean -> getOrNull(mean))
+      .filter(host -> host != null)
+      .findFirst()
+      .orElse(null);
+  }
+
+  @Nullable
+  private static String getOrNull(SupplierEx<String> s) {
+    try {
+      return s.get();
+    }
+    catch (Exception e) {
+      LOG.info("Failed to resolve local machine's hostname", e);
+      return null;
+    }
+  }
+
+  private static SupplierEx<String> env(String name) {
+    return () -> System.getenv(name);
+  }
+
+  /**
+   * "hostname" command works on Windows, Mac, and Linux.
+   * Usually much faster than {@link InetAddress#getLocalHost()}.
+   */
+  private static String executeHostname() throws IOException, InterruptedException {
+    Process p = new ProcessBuilder("hostname").start();
+
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+      String line = reader.readLine();
+      if (p.waitFor(5, SECONDS) && line != null) {
+        return line.trim();
+      }
+    }
+    return null;
+  }
+
+  private static String getLocalHost() throws UnknownHostException {
+    return InetAddress.getLocalHost().getHostName();
+  }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -1,25 +1,43 @@
 package org.littleshoot.proxy.impl;
 
-import static java.util.stream.Collectors.toList;
-
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 /** Utilities for the proxy. */
 public class ProxyUtils {
@@ -464,17 +482,9 @@ public class ProxyUtils {
    *
    * @return the local machine's hostname, or null if a hostname cannot be determined
    */
+  @Nullable
   public static String getHostName() {
-    try {
-      return InetAddress.getLocalHost().getHostName();
-    } catch (IOException | RuntimeException e) {
-      LOG.debug("Ignored exception", e);
-    } // An exception here must not stop the proxy. Android could throw a
-    // runtime exception, since it not allows network access in the main
-    // process.
-
-    LOG.info("Could not lookup localhost");
-    return null;
+    return Hostname.getHostName();
   }
 
   /**

--- a/src/main/java/org/littleshoot/proxy/impl/SupplierEx.java
+++ b/src/main/java/org/littleshoot/proxy/impl/SupplierEx.java
@@ -1,0 +1,6 @@
+package org.littleshoot.proxy.impl;
+
+@FunctionalInterface
+interface SupplierEx<T> {
+  T get() throws Exception;
+}

--- a/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
+++ b/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
@@ -1,20 +1,26 @@
 package org.littleshoot.proxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.littleshoot.proxy.test.HttpClientUtil.performHttpGet;
-import static org.littleshoot.proxy.test.HttpClientUtil.performLocalHttpGet;
-
-import io.netty.handler.codec.http.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import javax.net.ssl.SSLException;
-import org.jspecify.annotations.NonNull;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import javax.net.ssl.SSLException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.littleshoot.proxy.test.HttpClientUtil.performHttpGet;
+import static org.littleshoot.proxy.test.HttpClientUtil.performLocalHttpGet;
 
 /** This class tests direct requests to the proxy server, which causes endless loops (#205). */
 @NullMarked
@@ -61,12 +67,11 @@ public final class DirectRequestTest {
     final HttpResponseStatus status = HttpResponseStatus.valueOf(statusCode);
     HttpFiltersSource filtersSource =
         new HttpFiltersSourceAdapter() {
-          @NonNull
           @Override
-          public HttpFilters filterRequest(@NonNull HttpRequest originalRequest) {
+          public HttpFilters filterRequest(HttpRequest originalRequest) {
             return new HttpFiltersAdapter(originalRequest) {
               @Override
-              public HttpResponse clientToProxyRequest(@NonNull HttpObject httpObject) {
+              public HttpResponse clientToProxyRequest(HttpObject httpObject) {
                 return new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
               }
             };
@@ -109,13 +114,12 @@ public final class DirectRequestTest {
             .withProxyAlias("testAllowRequestToOriginServerWithOverride")
             .withFiltersSource(
                 new HttpFiltersSourceAdapter() {
-                  @NonNull
                   @Override
-                  public HttpFilters filterRequest(@NonNull HttpRequest originalRequest) {
+                  public HttpFilters filterRequest(HttpRequest originalRequest) {
                     return new HttpFiltersAdapter(originalRequest) {
                       @Nullable
                       @Override
-                      public HttpResponse clientToProxyRequest(@NonNull HttpObject httpObject) {
+                      public HttpResponse clientToProxyRequest(HttpObject httpObject) {
                         if (httpObject instanceof HttpRequest) {
                           HttpRequest request = (HttpRequest) httpObject;
                           String viaHeader = request.headers().get(HttpHeaderNames.VIA);

--- a/src/test/java/org/littleshoot/proxy/test/ThreadDumpExtension.java
+++ b/src/test/java/org/littleshoot/proxy/test/ThreadDumpExtension.java
@@ -1,9 +1,15 @@
 package org.littleshoot.proxy.test;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,11 +18,11 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Method;
 import java.util.concurrent.ScheduledExecutorService;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.extension.*;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.opentest4j.TestAbortedException;
-import org.slf4j.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class ThreadDumpExtension
     implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
@@ -41,12 +47,21 @@ public class ThreadDumpExtension
     log.info("starting {} ({})...", context.getDisplayName(), memory());
     ScheduledExecutorService executor = newScheduledThreadPool(1);
     executor.scheduleWithFixedDelay(
-        () -> takeThreadDump(log), INITIAL_DELAY_MS, DELAY_MS, MILLISECONDS);
+        () -> takeThreadDump(log), initialDelayMs(context), DELAY_MS, MILLISECONDS);
+
     context.getStore(NAMESPACE).put("executor", executor);
   }
 
+  private int initialDelayMs(ExtensionContext context) {
+    return context.getTestMethod()
+      .map(method -> method.getAnnotation(Timeout.class))
+      .map(timeout -> (int) timeout.unit().toMillis(timeout.value()) - 3000)
+      .map(timeout -> Math.max(timeout, 1000))
+      .orElse(INITIAL_DELAY_MS);
+  }
+
   @Override
-  public void afterEach(ExtensionContext context) throws Exception {
+  public void afterEach(ExtensionContext context) {
     logger(context)
         .info("finished {} - {} ({})", context.getDisplayName(), verdict(context), memory());
     ScheduledExecutorService executor =

--- a/src/test/java/org/littleshoot/proxy/test/ThreadDumpExtension.java
+++ b/src/test/java/org/littleshoot/proxy/test/ThreadDumpExtension.java
@@ -50,6 +50,11 @@ public class ThreadDumpExtension
         () -> takeThreadDump(log), initialDelayMs(context), DELAY_MS, MILLISECONDS);
 
     context.getStore(NAMESPACE).put("executor", executor);
+
+    String originalThreadName = Thread.currentThread().getName();
+    String newThreadName = String.format("%s-%s-%s", originalThreadName, context.getTestClass().map(Class::getName).orElse(""), context.getDisplayName());
+    Thread.currentThread().setName(newThreadName);
+    context.getStore(NAMESPACE).put("originalThreadName", originalThreadName);
   }
 
   private int initialDelayMs(ExtensionContext context) {
@@ -64,6 +69,8 @@ public class ThreadDumpExtension
   public void afterEach(ExtensionContext context) {
     logger(context)
         .info("finished {} - {} ({})", context.getDisplayName(), verdict(context), memory());
+    String originalThreadName = context.getStore(NAMESPACE).get("originalThreadName", String.class);
+    Thread.currentThread().setName(originalThreadName);
     ScheduledExecutorService executor =
         (ScheduledExecutorService) context.getStore(NAMESPACE).remove("executor");
     executor.shutdown();


### PR DESCRIPTION
1. This PR fixes flaky tests caused by slow resolution of hostname

By default, we start taking thread dumps after 8 seconds.

But some tests are annotated with `@Timeout(5)` - they fail before the 8th second. And we don't get thread dumps for these tests when they fail. :(

2. I guess the slow host resolution could also affect production code.