### PR TITLE
2 - Add timingData Map to FlowContext for storing timing metrics

### DIFF
--- a/src/main/java/org/littleshoot/proxy/FlowContext.java
+++ b/src/main/java/org/littleshoot/proxy/FlowContext.java
@@ -1,6 +1,8 @@
 package org.littleshoot.proxy;
 
 import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import org.littleshoot.proxy.impl.ClientToProxyConnection;
@@ -13,6 +15,7 @@ public class FlowContext {
   private final InetSocketAddress clientAddress;
   private final SSLSession clientSslSession;
   private final long connectionId;
+  private final Map<String, Long> timingData = new ConcurrentHashMap<>();
 
   public FlowContext(ClientToProxyConnection clientConnection) {
     clientAddress = clientConnection.getClientAddress();
@@ -29,6 +32,35 @@ public class FlowContext {
   /** If using SSL, this returns the {@link SSLSession} on the client connection. */
   public SSLSession getClientSslSession() {
     return clientSslSession;
+  }
+
+  /**
+   * Stores timing data for this flow.
+   *
+   * @param key the timing metric key
+   * @param value the timing value in milliseconds
+   */
+  public void setTimingData(String key, Long value) {
+    timingData.put(key, value);
+  }
+
+  /**
+   * Retrieves timing data for this flow.
+   *
+   * @param key the timing metric key
+   * @return the timing value in milliseconds, or null if not available
+   */
+  public Long getTimingData(String key) {
+    return timingData.get(key);
+  }
+
+  /**
+   * Gets all timing data for this flow.
+   *
+   * @return map of all timing data
+   */
+  public Map<String, Long> getTimings() {
+    return Map.copyOf(timingData);
   }
 
   @Override


### PR DESCRIPTION
- Add timingData ConcurrentHashMap to store timing metrics
- Add setTimingData(key, value) method to store timing values
- Add getTimingData(key) method to retrieve timing values
- Add getTimings() method to get copy of all timing data

This enables tracking of timing metrics like DNS resolution time, TCP connection time, SSL handshake time, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced per-flow timing metrics collection capabilities, enabling tracking and retrieval of performance data for individual flows within the proxy engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->