### PR TITLE
Feature/selective thread dump

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/Hostname.java
+++ b/src/main/java/org/littleshoot/proxy/impl/Hostname.java
@@ -1,8 +1,8 @@
 package org.littleshoot.proxy.impl;
 
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -10,10 +10,9 @@ import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.stream.Stream;
-
-import static java.lang.System.nanoTime;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class Hostname {
   private static final Logger LOG = LoggerFactory.getLogger(Hostname.class);
@@ -31,12 +30,12 @@ class Hostname {
   @Nullable
   private static String resolveHostName() {
     long startTime = nanoTime();
-    String hostName = byAllMeans(
-      env("HOSTNAME"), // Most OSs
-      env("COMPUTERNAME"), // Windows
-      Hostname::executeHostname,
-      Hostname::getLocalHost
-    );
+    String hostName =
+        byAllMeans(
+            env("HOSTNAME"), // Most OSs
+            env("COMPUTERNAME"), // Windows
+            Hostname::executeHostname,
+            Hostname::getLocalHost);
     long duration = NANOSECONDS.toMillis(nanoTime() - startTime);
     LOG.info("Resolved local machine's hostname \"{}\" in {} ms.", hostName, duration);
     return hostName;
@@ -46,18 +45,17 @@ class Hostname {
   @SafeVarargs
   private static String byAllMeans(SupplierEx<String>... means) {
     return Stream.of(means)
-      .map(mean -> getOrNull(mean))
-      .filter(host -> host != null)
-      .findFirst()
-      .orElse(null);
+        .map(mean -> getOrNull(mean))
+        .filter(host -> host != null)
+        .findFirst()
+        .orElse(null);
   }
 
   @Nullable
   private static String getOrNull(SupplierEx<String> s) {
     try {
       return s.get();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       LOG.info("Failed to resolve local machine's hostname", e);
       return null;
     }
@@ -68,8 +66,8 @@ class Hostname {
   }
 
   /**
-   * "hostname" command works on Windows, Mac, and Linux.
-   * Usually much faster than {@link InetAddress#getLocalHost()}.
+   * "hostname" command works on Windows, Mac, and Linux. Usually much faster than {@link
+   * InetAddress#getLocalHost()}.
    */
   private static String executeHostname() throws IOException, InterruptedException {
     Process p = new ProcessBuilder("hostname").start();

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -1,5 +1,7 @@
 package org.littleshoot.proxy.impl;
 
+import static java.util.stream.Collectors.toList;
+
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -18,14 +20,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.logging.log4j.util.Strings;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -36,8 +30,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utilities for the proxy. */
 public class ProxyUtils {

--- a/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
+++ b/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
@@ -1,5 +1,10 @@
 package org.littleshoot.proxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.littleshoot.proxy.test.HttpClientUtil.performHttpGet;
+import static org.littleshoot.proxy.test.HttpClientUtil.performLocalHttpGet;
+
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObject;
@@ -7,20 +12,14 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.SSLException;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
-
-import javax.net.ssl.SSLException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.littleshoot.proxy.test.HttpClientUtil.performHttpGet;
-import static org.littleshoot.proxy.test.HttpClientUtil.performLocalHttpGet;
 
 /** This class tests direct requests to the proxy server, which causes endless loops (#205). */
 @NullMarked

--- a/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
+++ b/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * end. Made into a unit test from isopov and nasis's contributions at: <a
  * href="https://github.com/adamfisk/LittleProxy/issues/36">...</a>
  */
+@EnableThreadDump
 public final class EndToEndStoppingTest {
   private static final Logger log = LoggerFactory.getLogger(EndToEndStoppingTest.class);
 

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -31,8 +31,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 import org.littleshoot.proxy.test.HttpClientUtil;
 
+@EnableThreadDump
 public final class HttpFilterTest {
   private Server webServer;
   private HttpProxyServer proxyServer;

--- a/src/test/java/org/littleshoot/proxy/IdleTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdleTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 
 /**
  * Note - this test only works on UNIX systems because it checks file descriptor counts.

--- a/src/test/java/org/littleshoot/proxy/IdleTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdleTest.java
@@ -20,6 +20,7 @@ import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
  * <p>It also fails on macOS (tested on 10.14 Mojave). It works on Ubuntu, and presumably most other
  * *nix systems.
  */
+@EnableThreadDump
 public final class IdleTest {
   private static final int NUMBER_OF_CONNECTIONS_TO_OPEN = 2000;
 

--- a/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
+++ b/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
@@ -15,6 +15,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 import org.littleshoot.proxy.test.SocketClientUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 @Tag("slow-test")
 @NullMarked
 @Timeout(20)
+@EnableThreadDump
 public final class KeepAliveTest {
   private static final Logger log = LoggerFactory.getLogger(KeepAliveTest.class);
   @Nullable private HttpProxyServer proxyServer;

--- a/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
+++ b/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
@@ -16,10 +16,12 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 
 @Tag("slow-test")
 @Timeout(25)
 @Execution(ExecutionMode.SAME_THREAD)
+@EnableThreadDump
 public final class ThrottlingTest {
   private static final int LARGE_DATA_SIZE = 200000;
   private static final long THROTTLED_READ_BYTES_PER_SECOND = 25000L;

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -18,8 +18,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 import org.littleshoot.proxy.test.SocketClientUtil;
 
+@EnableThreadDump
 public final class TimeoutTest {
 
   private static final String UNUSED_URI_FOR_BAD_GATEWAY = "http://1.2.3.6:53540";

--- a/src/test/java/org/littleshoot/proxy/impl/ClientToProxyTimeoutBugTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ClientToProxyTimeoutBugTest.java
@@ -320,4 +320,3 @@ public class ClientToProxyTimeoutBugTest {
     // - With fixed code: timeout handling is EXECUTED (correct!)
   }
 }
-

--- a/src/test/java/org/littleshoot/proxy/test/EnableThreadDump.java
+++ b/src/test/java/org/littleshoot/proxy/test/EnableThreadDump.java
@@ -1,0 +1,20 @@
+package org.littleshoot.proxy.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to enable thread dump generation for a test class or test method.
+ *
+ * <p>When present on a test class, thread dumps will be generated for all test methods in that
+ * class. When present on a specific test method, thread dumps will only be generated for that
+ * method.
+ *
+ * <p>This annotation is only effective when the {@link ThreadDumpExtension} is registered (either
+ * via service loader or via {@code @ExtendWith(ThreadDumpExtension.class)}).
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableThreadDump {}

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
@@ -12,6 +12,7 @@ import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
 import org.littleshoot.proxy.extras.TestMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.EnableThreadDump;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
+++ b/src/test/java/org/littleshoot/proxy/websockets/WebSocketClientServerTest.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag("slow-test")
+@EnableThreadDump
 public final class WebSocketClientServerTest {
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(5);


### PR DESCRIPTION
Executing some Thread dump for all unit tests seems excessive. I've coupled it with an annotation, and added it to relevant unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved thread dump diagnostics for test execution debugging.

* **Style & Refactor**
  * Reorganized imports across source and test files for consistency.
  * Adjusted code formatting throughout the codebase.

* **Chores**
  * Minor code cleanup and whitespace adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->