### PR TITLE
Fix order of handlers in ClientToProxyConnection to support proxy protocol decoding for inbound requests

### DIFF
--- a/src/main/java/org/littleshoot/proxy/FlowContext.java
+++ b/src/main/java/org/littleshoot/proxy/FlowContext.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy;
 
+import io.netty.handler.codec.haproxy.HAProxyMessage;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Objects;
@@ -13,26 +14,33 @@ import org.littleshoot.proxy.impl.ClientToProxyConnection;
  * ActivityTracker}.
  */
 public class FlowContext {
-  private final InetSocketAddress clientAddress;
-  private final SSLSession clientSslSession;
+  private final ClientToProxyConnection clientConnection;
   private final long connectionId;
   private final Map<String, Long> timingData = new ConcurrentHashMap<>();
 
   public FlowContext(ClientToProxyConnection clientConnection) {
-    clientAddress = clientConnection.getClientAddress();
-    SSLEngine sslEngine = clientConnection.getSslEngine();
-    clientSslSession = sslEngine != null ? sslEngine.getSession() : null;
+    this.clientConnection = clientConnection;
     this.connectionId = clientConnection.getId();
   }
 
-  /** The address of the client. */
+  /**
+   * The client's address: the PROXY header's source address when PROXY protocol is in use,
+   * otherwise the TCP peer. Resolved lazily so a header received after construction is reflected.
+   */
   public InetSocketAddress getClientAddress() {
-    return clientAddress;
+    HAProxyMessage haProxyMessage = clientConnection.getHaProxyMessage();
+    if (haProxyMessage != null
+        && haProxyMessage.sourceAddress() != null
+        && !haProxyMessage.sourceAddress().isBlank()) {
+      return new InetSocketAddress(haProxyMessage.sourceAddress(), haProxyMessage.sourcePort());
+    }
+    return clientConnection.getClientAddress();
   }
 
   /** If using SSL, this returns the {@link SSLSession} on the client connection. */
   public SSLSession getClientSslSession() {
-    return clientSslSession;
+    SSLEngine sslEngine = clientConnection.getSslEngine();
+    return sslEngine != null ? sslEngine.getSession() : null;
   }
 
   /**

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -109,7 +109,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
   private final AtomicInteger numberOfCurrentlyConnectingServers = new AtomicInteger(0);
 
   /** Keep track of proxy protocol header */
-  private HAProxyMessage haProxyMessage;
+  @Nullable private volatile HAProxyMessage haProxyMessage;
 
   /** Keep track of how many servers are currently connected. */
   private final AtomicInteger numberOfCurrentlyConnectedServers = new AtomicInteger(0);
@@ -133,6 +133,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
   private final AtomicBoolean authenticated = new AtomicBoolean();
 
+  /** Ensures {@link #recordClientConnected()} fires at most once per connection. */
+  private static final boolean CLIENT_CONNECTED_NOT_YET_RECORDED = false;
+
+  private static final boolean CLIENT_CONNECTED_RECORDED = true;
+  private final AtomicBoolean clientConnectedRecorded = new AtomicBoolean();
+
   private final GlobalTrafficShapingHandler globalTrafficShapingHandler;
 
   /** Cached FlowContext for consistent timing data across client lifecycle events. */
@@ -152,21 +158,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     super(AWAITING_INITIAL, proxyServer, false);
     this.clientFlowContext = new FlowContext(this);
 
-    initChannelPipeline(pipeline);
+    initChannelPipeline(pipeline, sslEngineSource, authenticateClients);
 
-    if (sslEngineSource != null) {
-      LOG.debug("Enabling encryption of traffic from client to proxy");
-      SSLEngine sslEngine = sslEngineSource.newSslEngine();
-      recordClientSSLHandshakeStarted();
-      encrypt(pipeline, sslEngine, authenticateClients)
-          .addListener(
-              future -> {
-                if (future.isSuccess()) {
-                  clientSslSession = sslEngine.getSession();
-                  recordClientSSLHandshakeSucceeded();
-                }
-              });
-    }
     this.globalTrafficShapingHandler = globalTrafficShapingHandler;
 
     LOG.debug("Created ClientToProxyConnection");
@@ -175,6 +168,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
   @Override
   protected void readHAProxyMessage(HAProxyMessage msg) {
     haProxyMessage = msg;
+    // PROXY header available: fire the deferred clientConnected now (guarded).
+    recordClientConnected();
   }
 
   /* *************************************************************************
@@ -184,6 +179,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
   @Override
   ConnectionState readHTTPInitial(HttpRequest httpRequest) {
     LOG.debug("Received raw request: {}", httpRequest);
+
+    // Earliest point to report connected for connections with no PROXY header (guarded; no-op if already fired).
+    recordClientConnected();
 
     // if we cannot parse the request, immediately return a 400 and close the connection, since we
     // do not know what state
@@ -558,7 +556,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
   protected void connected() {
     super.connected();
     become(AWAITING_INITIAL);
-    recordClientConnected();
+    // recordClientConnected() is deferred, not called here: with PROXY protocol it must wait for the
+    // header so it reports the real client address (readHAProxyMessage); otherwise it fires on the
+    // first request (readHTTPInitial). The header isn't available yet at channel-active time.
   }
 
   void timedOut(ProxyToServerConnection serverConnection) {
@@ -836,17 +836,27 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
    * <p>Regarding the Javadoc of {@link HttpObjectAggregator} it's needed to have the {@link
    * HttpResponseEncoder} or {@link io.netty.handler.codec.http.HttpRequestEncoder} before the
    * {@link HttpObjectAggregator} in the {@link ChannelPipeline}.
+   *
+   * <p>If an {@link SslEngineSource} is provided, SSL encryption is enabled on the pipeline. When
+   * the proxy protocol is enabled, the {@link HAProxyMessageDecoder} is added after the SSL handler
+   * setup to ensure it is positioned before the {@link io.netty.handler.ssl.SslHandler} in the
+   * inbound pipeline, so that the PROXY protocol header is decoded before the TLS handshake begins.
+   *
+   * @param pipeline the {@link ChannelPipeline} to configure
+   * @param sslEngineSource the {@link SslEngineSource} for client-to-proxy encryption, or {@code
+   *     null} if SSL is not enabled
+   * @param authenticateClients whether to require client certificate authentication
    */
-  private void initChannelPipeline(ChannelPipeline pipeline) {
+  private void initChannelPipeline(
+      ChannelPipeline pipeline,
+      @Nullable SslEngineSource sslEngineSource,
+      boolean authenticateClients) {
     LOG.debug("Configuring ChannelPipeline");
 
     pipeline.addLast("bytesReadMonitor", bytesReadMonitor);
     pipeline.addLast("bytesWrittenMonitor", bytesWrittenMonitor);
 
     pipeline.addLast(HTTP_ENCODER_NAME, new HttpResponseEncoder());
-    if (isAcceptProxyProtocol()) {
-      pipeline.addLast(HTTP_PROXY_DECODER_NAME, new HAProxyMessageDecoder());
-    }
     // We want to allow longer request lines, headers, and chunks
     // respectively.
     pipeline.addLast(
@@ -868,6 +878,24 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     pipeline.addLast("idle", new IdleStateHandler(0, 0, proxyServer.getIdleConnectionTimeout()));
 
     pipeline.addLast(MAIN_HANDLER_NAME, this);
+
+    if (sslEngineSource != null) {
+      LOG.debug("Enabling encryption of traffic from client to proxy");
+      SSLEngine sslEngine = sslEngineSource.newSslEngine();
+      recordClientSSLHandshakeStarted();
+      encrypt(pipeline, sslEngine, authenticateClients)
+          .addListener(
+              future -> {
+                if (future.isSuccess()) {
+                  clientSslSession = sslEngine.getSession();
+                  recordClientSSLHandshakeSucceeded();
+                }
+              });
+    }
+
+    if (isAcceptProxyProtocol()) {
+      pipeline.addFirst(HTTP_PROXY_DECODER_NAME, new HAProxyMessageDecoder());
+    }
   }
 
   private void removeHandlerIfPresent(String name) {
@@ -1588,10 +1616,14 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
       };
 
   private void recordClientConnected() {
+    if (!clientConnectedRecorded.compareAndSet(
+        CLIENT_CONNECTED_NOT_YET_RECORDED, CLIENT_CONNECTED_RECORDED)) {
+      return;
+    }
     try {
-      InetSocketAddress clientAddress = getClientAddress();
-      clientDetails.setClientAddress(clientAddress);
       FlowContext flowContext = flowContext();
+      // Resolve via FlowContext so ClientDetails (used for chained-proxy routing) sees the real client IP, not the TCP peer.
+      clientDetails.setClientAddress(flowContext.getClientAddress());
       for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
         tracker.clientConnected(flowContext);
       }
@@ -1623,6 +1655,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
   }
 
   private void recordClientDisconnected() {
+    // Ensure clientConnected was reported before clientDisconnected, even for silent connections
+    // (guarded).
+    recordClientConnected();
     FlowContext flowContext = flowContext();
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {
@@ -1699,7 +1734,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     serverFlowContexts.remove(serverConnection);
   }
 
-  public HAProxyMessage getHaProxyMessage() {
+  public @Nullable HAProxyMessage getHaProxyMessage() {
     return haProxyMessage;
   }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
@@ -1,14 +1,8 @@
 package org.littleshoot.proxy.impl;
 
-import io.netty.handler.codec.haproxy.HAProxyCommand;
-import io.netty.handler.codec.haproxy.HAProxyMessage;
-import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
-import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.util.concurrent.Future;
-import java.net.InetSocketAddress;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import org.littleshoot.proxy.extras.ProxyProtocolMessage;
 
 /**
  * Coordinates the various steps involved in establishing a connection, such as establishing a
@@ -142,36 +136,8 @@ class ConnectionFlow {
     synchronized (connectLock) {
       serverConnection.getLOG().debug("Connection flow completed successfully: {}", currentStep);
       serverConnection.connectionSucceeded(!suppressInitialRequest);
-      relayProxyInformation();
       notifyThreadsWaitingForConnection();
     }
-  }
-
-  private void relayProxyInformation() {
-    if (clientConnection.isSendProxyProtocol()) {
-      ProxyProtocolMessage proxyProtocolMessage =
-          getHAProxyMessage(
-              clientConnection.getClientAddress(), serverConnection.getRemoteAddress());
-      if (proxyProtocolMessage != null) {
-        serverConnection.writeToChannel(proxyProtocolMessage);
-      }
-    }
-  }
-
-  private ProxyProtocolMessage getHAProxyMessage(
-      InetSocketAddress clientAddress, InetSocketAddress remoteAddress) {
-    HAProxyMessage haProxyMessage = clientConnection.getHaProxyMessage();
-    if (haProxyMessage != null) {
-      return new ProxyProtocolMessage(haProxyMessage);
-    }
-    return new ProxyProtocolMessage(
-        HAProxyProtocolVersion.V1,
-        HAProxyCommand.PROXY,
-        HAProxyProxiedProtocol.TCP4,
-        clientAddress.getAddress().getHostAddress(),
-        remoteAddress.getAddress().getHostAddress(),
-        clientAddress.getPort(),
-        remoteAddress.getPort());
   }
 
   /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -20,7 +20,10 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
@@ -72,6 +75,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
@@ -89,6 +93,7 @@ import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.TransportProtocol;
 import org.littleshoot.proxy.UnknownTransportProtocolException;
 import org.littleshoot.proxy.extras.HAProxyMessageEncoder;
+import org.littleshoot.proxy.extras.ProxyProtocolMessage;
 
 /**
  * Represents a connection from our proxy to a server on the web. ProxyConnections are reused fairly
@@ -600,9 +605,41 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
   private void initializeConnectionFlow() {
     connectionFlow = new ConnectionFlow(clientConnection, this, connectLock).then(ConnectChannel);
 
-    if (hasUpstreamChainedProxy()) {
+    boolean sendProxyProtocol = proxyServer.isSendProxyProtocol();
+    boolean chained = hasUpstreamChainedProxy();
+    boolean chainedSocks =
+        chained
+            && (chainedProxyType == ChainedProxyType.SOCKS4
+                || chainedProxyType == ChainedProxyType.SOCKS5);
+    boolean chainedHttp = chained && chainedProxyType == ChainedProxyType.HTTP;
+    boolean isConnect = ProxyUtils.isCONNECT(initialRequest);
+
+    // Where to write the PROXY header so it reaches the final server:
+    //  - Direct: first, right after connecting (peer is the final server).
+    //  - HTTP CONNECT chain: tunnelled after the CONNECT handshake (see the CONNECT block below);
+    //    the intermediate sees a plain CONNECT.
+    //  - SOCKS chain: skipped (warning).
+    //  - Non-CONNECT HTTP chain: skipped (warning) - no tunnel to the final server.
+    boolean sendProxyHeaderFirst = sendProxyProtocol && !chained;
+    boolean tunnelProxyHeaderThroughConnect = sendProxyProtocol && chainedHttp && isConnect;
+
+    if (sendProxyProtocol && chainedSocks) {
+      LOG.warn(
+          "PROXY protocol is not compatible with SOCKS upstream proxies ({}). Skipping PROXY header.",
+          chainedProxyType);
+    } else if (sendProxyProtocol && chainedHttp && !isConnect) {
+      LOG.warn(
+          "PROXY protocol cannot be forwarded through a non-CONNECT HTTP chained proxy. "
+              + "Skipping PROXY header.");
+    }
+
+    if (sendProxyHeaderFirst) {
+      connectionFlow.then(SendProxyProtocolHeader);
+    }
+
+    if (chained) {
       if (chainedProxy.requiresEncryption()) {
-        connectionFlow.then(serverConnection.EncryptChannel(chainedProxy.newSslEngine()));
+        connectionFlow.then(serverConnection.EncryptChannel(newChainedProxySslEngine()));
       }
       switch (chainedProxyType) {
         case SOCKS4:
@@ -616,11 +653,18 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
       }
     }
 
-    if (ProxyUtils.isCONNECT(initialRequest)) {
+    if (isConnect) {
       // If we're chaining to an upstream HTTP proxy, forward the CONNECT request.
       // Do not chain the CONNECT request for SOCKS proxies.
-      if (hasUpstreamChainedProxy() && (chainedProxyType == ChainedProxyType.HTTP)) {
+      if (chainedHttp) {
         connectionFlow.then(serverConnection.HTTPCONNECTWithChainedProxy);
+      }
+
+      // Write the PROXY header into the established tunnel (first bytes to the final server),
+      // before
+      // StartTunneling/EncryptChannel remove the HAProxyMessageEncoder.
+      if (tunnelProxyHeaderThroughConnect) {
+        connectionFlow.then(SendProxyProtocolHeader);
       }
 
       MitmManager mitmManager = proxyServer.getMitmManager();
@@ -657,6 +701,49 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
       }
     }
   }
+
+  SSLEngine newChainedProxySslEngine() {
+    if (remoteAddress != null) {
+      SSLEngine peerAwareSslEngine =
+          chainedProxy.newSslEngine(remoteAddress.getHostString(), remoteAddress.getPort());
+      if (peerAwareSslEngine != null) {
+        return peerAwareSslEngine;
+      }
+    }
+
+    return chainedProxy.newSslEngine();
+  }
+
+  private final ConnectionFlowStep<HttpResponse> SendProxyProtocolHeader =
+      new ConnectionFlowStep<>(this, CONNECTING) {
+        @Override
+        protected Future<?> execute() {
+          HAProxyMessage haProxyMessage = clientConnection.getHaProxyMessage();
+          ProxyProtocolMessage proxyProtocolMessage;
+          if (haProxyMessage != null) {
+            proxyProtocolMessage = new ProxyProtocolMessage(haProxyMessage);
+          } else {
+            InetSocketAddress clientAddr = clientConnection.getClientAddress();
+            if (clientAddr == null
+                || clientAddr.getAddress() == null
+                || remoteAddress == null
+                || remoteAddress.getAddress() == null) {
+              LOG.warn("Cannot send PROXY protocol header: addresses not available");
+              return channel.newSucceededFuture();
+            }
+            proxyProtocolMessage =
+                new ProxyProtocolMessage(
+                    HAProxyProtocolVersion.V1,
+                    HAProxyCommand.PROXY,
+                    HAProxyProxiedProtocol.TCP4,
+                    clientAddr.getAddress().getHostAddress(),
+                    remoteAddress.getAddress().getHostAddress(),
+                    clientAddr.getPort(),
+                    remoteAddress.getPort());
+          }
+          return writeToChannel(proxyProtocolMessage);
+        }
+      };
 
   private void addFirstOrReplaceHandler(String name, ChannelHandler handler) {
     if (channel.pipeline().context(name) != null) {
@@ -1328,7 +1415,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         }
       };
 
-  private void recordServerConnected() {
+  void recordServerConnected() {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {
@@ -1339,7 +1426,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
   }
 
-  private void recordServerDisconnected() {
+  void recordServerDisconnected() {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     try {
       for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
@@ -1354,7 +1441,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
   }
 
-  private void recordConnectionSaturated() {
+  void recordConnectionSaturated() {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {
@@ -1365,7 +1452,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
   }
 
-  private void recordConnectionWritable() {
+  void recordConnectionWritable() {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {
@@ -1376,7 +1463,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
   }
 
-  private void recordConnectionTimedOut() {
+  void recordConnectionTimedOut() {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {
@@ -1387,7 +1474,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     }
   }
 
-  private void recordConnectionExceptionCaught(Throwable cause) {
+  void recordConnectionExceptionCaught(Throwable cause) {
     FullFlowContext flowContext = clientConnection.flowContextForServerConnection(this);
     for (ActivityTracker tracker : proxyServer.getActivityTrackers()) {
       try {

--- a/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
@@ -40,7 +40,7 @@ abstract class BaseChainedSocksProxyTest extends BaseProxyTest {
     }
   }
 
-  private void initializeSocksServer() throws Exception {
+  protected void initializeSocksServer() throws Exception {
     socksBossGroup = new NioEventLoopGroup(1);
     socksWorkerGroup = new NioEventLoopGroup();
 
@@ -55,7 +55,7 @@ abstract class BaseChainedSocksProxyTest extends BaseProxyTest {
     socksPort = ((InetSocketAddress) channelFuture.channel().localAddress()).getPort();
   }
 
-  private ChainedProxyManager chainedProxyManager() {
+  protected ChainedProxyManager chainedProxyManager() {
     return (httpRequest, chainedProxies, details) ->
         chainedProxies.add(
             new ChainedProxyAdapter() {

--- a/src/test/java/org/littleshoot/proxy/Socks4ChainedProxyWithMissConfiguredSendProxyProtocolTest.java
+++ b/src/test/java/org/littleshoot/proxy/Socks4ChainedProxyWithMissConfiguredSendProxyProtocolTest.java
@@ -1,0 +1,25 @@
+package org.littleshoot.proxy;
+
+import org.junit.jupiter.api.Tag;
+
+@Tag("slow-test")
+public final class Socks4ChainedProxyWithMissConfiguredSendProxyProtocolTest
+    extends BaseChainedSocksProxyTest {
+  @Override
+  protected ChainedProxyType getSocksProxyType() {
+    return ChainedProxyType.SOCKS4;
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    initializeSocksServer();
+    proxyServer =
+        bootstrapProxy()
+            .withName("Downstream")
+            .withPort(0)
+            .withChainProxyManager(chainedProxyManager())
+            // misconfigured option
+            .withSendProxyProtocol(true)
+            .start();
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/Socks5ChainedProxyWithMissConfiguredSendProxyProtocolTest.java
+++ b/src/test/java/org/littleshoot/proxy/Socks5ChainedProxyWithMissConfiguredSendProxyProtocolTest.java
@@ -1,0 +1,25 @@
+package org.littleshoot.proxy;
+
+import org.junit.jupiter.api.Tag;
+
+@Tag("slow-test")
+public final class Socks5ChainedProxyWithMissConfiguredSendProxyProtocolTest
+    extends BaseChainedSocksProxyTest {
+  @Override
+  protected ChainedProxyType getSocksProxyType() {
+    return ChainedProxyType.SOCKS5;
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    initializeSocksServer();
+    proxyServer =
+        bootstrapProxy()
+            .withName("Downstream")
+            .withPort(0)
+            .withChainProxyManager(chainedProxyManager())
+            // misconfigured option
+            .withSendProxyProtocol(true)
+            .start();
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSourceTest.java
+++ b/src/test/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSourceTest.java
@@ -16,17 +16,22 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 final class SelfSignedSslEngineSourceTest {
 
   private static final String DEFAULT_KEYSTORE = "littleproxy_keystore.jks";
   private static final int BUFFER_CAPACITY = 32768;
 
   @TempDir File tempDir;
+
+  @BeforeEach
+  void cleanDefaultKeystore() {
+    deleteIfExistsOrFail(new File(DEFAULT_KEYSTORE));
+    deleteIfExistsOrFail(new File("littleproxy_cert"));
+  }
 
   private static boolean isKeytoolAvailable() {
     ProcessBuilder pb = new ProcessBuilder("keytool", "-help");
@@ -40,12 +45,27 @@ final class SelfSignedSslEngineSourceTest {
     }
   }
 
+  private static void deleteIfExistsOrFail(File file) {
+    if (file.exists()) {
+      assertThat(file.delete())
+          .as("Failed to delete stale test artifact: " + file.getAbsolutePath())
+          .isTrue();
+    }
+  }
+
   @BeforeAll
   static void setUp() {
     Assumptions.assumeTrue(isKeytoolAvailable(), "keytool is not installed, test ignored");
   }
 
+  @AfterAll
+  static void cleanUp() {
+    deleteIfExistsOrFail(new File(DEFAULT_KEYSTORE));
+    deleteIfExistsOrFail(new File("littleproxy_cert"));
+  }
+
   @Test
+  @Order(1)
   void defaultConstructor() {
     // The default constructor creates "littleproxy_keystore.jks" in the working directory
     // Clean up any existing keystore first to ensure the test is deterministic
@@ -97,6 +117,7 @@ final class SelfSignedSslEngineSourceTest {
   }
 
   @Test
+  @Order(2)
   void constructorWithTrustAllServersGeneratesDefaultKeystore() {
     // Test trustAllServers=true with default keystore path
     // Delete any existing default keystore to test generation
@@ -125,6 +146,7 @@ final class SelfSignedSslEngineSourceTest {
   }
 
   @Test
+  @Order(3)
   void constructorWithTrustAllServersReusesExistingKeystore() {
     // Test that existing default keystore is reused
     File defaultKeystore = new File(DEFAULT_KEYSTORE);

--- a/src/test/java/org/littleshoot/proxy/haproxy/BaseProxyProtocolTest.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/BaseProxyProtocolTest.java
@@ -14,21 +14,45 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 import org.junit.jupiter.api.AfterEach;
 import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.SslEngineSource;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 /**
  * Base for running Proxy protocol tests. Proxy Protocol tests need special client and servers that
  * are capable of emitting and consuming proxy protocol headers.
+ *
+ * <p>Subclasses may override {@link #useTlsInbound()} to enable TLS between the client and the
+ * proxy. When TLS is enabled, the client sends the PROXY protocol header as cleartext
+ * <em>before</em> the TLS handshake, matching real-world deployments (e.g. AWS NLB → proxy).
+ *
+ * <p>Subclasses may override {@link #sendProxyHeaderBeforeTls()} to control the ordering of the
+ * PROXY header relative to the TLS handshake. Returning {@code false} causes the PROXY header to be
+ * sent <em>inside</em> the TLS tunnel (after the handshake), which is useful for negative testing.
  */
 public abstract class BaseProxyProtocolTest {
 
+  protected CountDownLatch clientTlsHandshakeDone;
+  private CountDownLatch serverHandlerReady;
   private EventLoopGroup childGroup;
   private EventLoopGroup parentGroup;
+  private EventLoopGroup clientWorkGroup;
   private ProxyProtocolServerHandler proxyProtocolServerHandler;
+
   private HttpProxyServer proxyServer;
   private int proxyPort;
   private boolean acceptProxy = true;
@@ -38,10 +62,30 @@ public abstract class BaseProxyProtocolTest {
   static final String DESTINATION_ADDRESS = "192.168.0.154";
   static final String SOURCE_PORT = "123";
   static final String DESTINATION_PORT = "456";
+  private volatile ProxyProtocolClientHandler clientHandler;
+
+  protected boolean useTlsInbound() {
+    return false;
+  }
+
+  /** Controls whether the PROXY protocol header is sent before or after the TLS handshake. */
+  protected boolean sendProxyHeaderBeforeTls() {
+    return true;
+  }
+
+  boolean isClientTlsHandshakeSuccess() {
+    return clientHandler != null && clientHandler.isTlsHandshakeSuccess();
+  }
+
+  Throwable getClientTlsHandshakeFailureCause() {
+    return clientHandler != null ? clientHandler.getTlsHandshakeFailureCause() : null;
+  }
 
   protected final void setup(boolean acceptProxy, boolean sendProxy) throws Exception {
     this.acceptProxy = acceptProxy;
     this.sendProxy = sendProxy;
+    this.serverHandlerReady = new CountDownLatch(1);
+    this.clientTlsHandshakeDone = new CountDownLatch(1);
     startProxyServer();
     startServer();
     startClient();
@@ -62,6 +106,7 @@ public abstract class BaseProxyProtocolTest {
                     .addLast(new HAProxyMessageDecoder())
                     .addLast(new HttpRequestDecoder())
                     .addLast(proxyProtocolServerHandler);
+                serverHandlerReady.countDown();
               }
             })
         .option(ChannelOption.SO_BACKLOG, 128)
@@ -78,7 +123,7 @@ public abstract class BaseProxyProtocolTest {
 
   final void startClient() throws Exception {
     String host = "localhost";
-    EventLoopGroup clientWorkGroup = new NioEventLoopGroup();
+    clientWorkGroup = new NioEventLoopGroup();
     Bootstrap b = new Bootstrap();
     b.group(clientWorkGroup);
     b.channel(NioSocketChannel.class);
@@ -86,22 +131,45 @@ public abstract class BaseProxyProtocolTest {
     b.handler(
         new ChannelInitializer<SocketChannel>() {
           @Override
-          public void initChannel(SocketChannel ch) {
+          public void initChannel(SocketChannel ch) throws SSLException {
             ch.pipeline().addLast(new ReadTimeoutHandler(1));
-            if (acceptProxy) {
+            if (!useTlsInbound() && acceptProxy) {
               ch.pipeline().addLast(new ProxyProtocolTestEncoder());
             }
+
+            // Build client SslContext for TLS cases.
+            SslContext clientSslCtx = null;
+            if (useTlsInbound()) {
+              clientSslCtx =
+                  SslContextBuilder.forClient()
+                      .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                      .build();
+            }
+
+            clientHandler =
+                new ProxyProtocolClientHandler(
+                    serverPort,
+                    getProxyProtocolHeader(),
+                    clientSslCtx,
+                    proxyPort,
+                    clientTlsHandshakeDone,
+                    sendProxyHeaderBeforeTls(),
+                    acceptProxy);
+
             ch.pipeline()
+                .addLast(new HttpResponseDecoder())
                 .addLast(new HttpRequestEncoder())
-                .addLast(new ProxyProtocolClientHandler(serverPort, getProxyProtocolHeader()));
+                .addLast(clientHandler);
           }
         });
-    ChannelFuture f = b.connect(host, proxyPort).sync();
-    f.channel().closeFuture().sync();
+    b.connect(host, proxyPort).sync();
   }
 
-  HAProxyMessage getRelayedHaProxyMessage() {
-    return proxyProtocolServerHandler.getHaProxyMessage();
+  HAProxyMessage getRelayedHaProxyMessage() throws InterruptedException {
+    if (!serverHandlerReady.await(5, TimeUnit.SECONDS)) {
+      return null;
+    }
+    return proxyProtocolServerHandler.awaitHaProxyMessage(3, TimeUnit.SECONDS);
   }
 
   private void stopServer() {
@@ -113,15 +181,45 @@ public abstract class BaseProxyProtocolTest {
     proxyServer.abort();
   }
 
-  private void startProxyServer() {
-    proxyServer =
+  private void startProxyServer() throws CertificateException, SSLException {
+    HttpProxyServerBootstrap builder =
         DefaultHttpProxyServer.bootstrap()
             .withPort(0)
             .withAcceptProxyProtocol(acceptProxy)
-            .withSendProxyProtocol(sendProxy)
-            .start();
+            .withSendProxyProtocol(sendProxy);
+
+    if (useTlsInbound()) {
+      SelfSignedCertificate ssc = new SelfSignedCertificate();
+      SslContext sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+
+      builder.withSslEngineSource(
+          new SslEngineSource() {
+            @Override
+            public SSLEngine newSslEngine() {
+              return sslCtx.newEngine(io.netty.buffer.ByteBufAllocator.DEFAULT);
+            }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+              return sslCtx.newEngine(io.netty.buffer.ByteBufAllocator.DEFAULT, peerHost, peerPort);
+            }
+          });
+
+      builder.withAuthenticateSslClients(false);
+    }
+
+    customizeProxyServer(builder);
+
+    proxyServer = builder.start();
     proxyPort = proxyServer.getListenAddress().getPort();
   }
+
+  /**
+   * Hook for subclasses to further configure the proxy bootstrap (e.g. attach an {@link
+   * org.littleshoot.proxy.ActivityTracker} or {@link org.littleshoot.proxy.ChainedProxyManager})
+   * before it is started. Default is a no-op.
+   */
+  protected void customizeProxyServer(HttpProxyServerBootstrap builder) {}
 
   private ProxyProtocolHeader getProxyProtocolHeader() {
     return new ProxyProtocolHeader(
@@ -132,5 +230,8 @@ public abstract class BaseProxyProtocolTest {
   final void tearDown() {
     stopServer();
     stopProxyServer();
+    if (clientWorkGroup != null) {
+      clientWorkGroup.shutdownGracefully();
+    }
   }
 }

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolClientHandler.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolClientHandler.java
@@ -1,27 +1,160 @@
 package org.littleshoot.proxy.haproxy;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
 
 public class ProxyProtocolClientHandler extends ChannelInboundHandlerAdapter {
 
   private static final String HOST = "http://localhost";
   private final int serverPort;
   private final ProxyProtocolHeader proxyProtocolHeader;
+  private final SslContext clientSslContext;
+  private final int proxyPort;
+  private final CountDownLatch tlsHandshakeDone;
+  private final boolean sendProxyBeforeTls;
+  private final boolean sendInboundProxyHeader;
+  private volatile boolean tlsHandshakeSuccess;
+  private volatile Throwable tlsHandshakeFailureCause;
 
-  ProxyProtocolClientHandler(int serverPort, ProxyProtocolHeader proxyProtocolHeader) {
+  ProxyProtocolClientHandler(
+      int serverPort,
+      ProxyProtocolHeader proxyProtocolHeader,
+      SslContext clientSslContext,
+      int proxyPort,
+      CountDownLatch tlsHandshakeDone,
+      boolean sendProxyBeforeTls,
+      boolean sendInboundProxyHeader) {
     this.serverPort = serverPort;
     this.proxyProtocolHeader = proxyProtocolHeader;
+    this.clientSslContext = clientSslContext;
+    this.proxyPort = proxyPort;
+    this.tlsHandshakeDone = tlsHandshakeDone;
+    this.sendProxyBeforeTls = sendProxyBeforeTls;
+    this.sendInboundProxyHeader = sendInboundProxyHeader;
   }
 
   @Override
   public void channelActive(ChannelHandlerContext ctx) {
-    ctx.write(getHAProxyHeader());
-    ctx.writeAndFlush(getConnectRequest());
+    if (clientSslContext != null) {
+      if (sendProxyBeforeTls) {
+        // Correct order: write PROXY header as raw cleartext bytes, then
+        // add SslHandler and send CONNECT once TLS handshake completes.
+        sendProxyThenTls(ctx);
+      } else {
+        // Wrong order: TLS first, then PROXY header inside the encrypted tunnel.
+        sendTlsThenProxy(ctx);
+      }
+    } else {
+      // Non-TLS mode: send PROXY header + CONNECT directly.
+      if (sendInboundProxyHeader) {
+        ctx.write(getHAProxyHeader());
+      }
+      ctx.writeAndFlush(getConnectRequest());
+    }
+  }
+
+  /** Correct order: cleartext PROXY header → TLS handshake → HTTP CONNECT. */
+  private void sendProxyThenTls(ChannelHandlerContext ctx) {
+    ByteBuf buf = ctx.alloc().buffer();
+    buf.writeBytes(getHAProxyHeader().getBytes(StandardCharsets.US_ASCII));
+
+    // Write through the pipeline head to bypass HttpRequestEncoder,
+    // which only handles HttpRequest/HttpContent, not raw ByteBuf.
+    ctx.pipeline()
+        .firstContext()
+        .writeAndFlush(buf)
+        .addListener(
+            (ChannelFutureListener)
+                future -> {
+                  if (!future.isSuccess()) {
+                    signalTlsDone(false, future.cause());
+                    ctx.close();
+                    return;
+                  }
+                  addSslAndConnect(ctx);
+                });
+  }
+
+  /**
+   * Wrong order (for negative testing): TLS handshake first → PROXY header sent inside the
+   * encrypted tunnel → proxy cannot decode it.
+   */
+  private void sendTlsThenProxy(ChannelHandlerContext ctx) {
+    SslHandler sslHandler = clientSslContext.newHandler(ctx.alloc(), "localhost", proxyPort);
+    ctx.pipeline().addFirst("ssl", sslHandler);
+
+    sslHandler
+        .handshakeFuture()
+        .addListener(
+            (GenericFutureListener<? extends Future<? super Channel>>)
+                hsFuture -> {
+                  signalTlsDone(hsFuture.isSuccess(), hsFuture.cause());
+                  if (hsFuture.isSuccess()) {
+                    // PROXY header is now encrypted — proxy can't decode it.
+                    ByteBuf buf = ctx.alloc().buffer();
+                    buf.writeBytes(getHAProxyHeader().getBytes(StandardCharsets.US_ASCII));
+                    ctx.writeAndFlush(buf);
+                    ctx.writeAndFlush(getConnectRequest());
+                  } else {
+                    ctx.close();
+                  }
+                });
+  }
+
+  /** Adds the SslHandler and sends CONNECT after the handshake succeeds. */
+  private void addSslAndConnect(ChannelHandlerContext ctx) {
+    ChannelPipeline pipeline = ctx.pipeline();
+    SslHandler sslHandler = clientSslContext.newHandler(ctx.alloc(), "localhost", proxyPort);
+    pipeline.addFirst("ssl", sslHandler);
+
+    sslHandler
+        .handshakeFuture()
+        .addListener(
+            (GenericFutureListener<? extends Future<? super Channel>>)
+                hsFuture -> {
+                  signalTlsDone(hsFuture.isSuccess(), hsFuture.cause());
+                  if (hsFuture.isSuccess()) {
+                    ctx.writeAndFlush(getConnectRequest());
+                  } else {
+                    ctx.close();
+                  }
+                });
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) {
+    if (msg instanceof HttpResponse) {
+      ReferenceCountUtil.release(msg);
+      ctx.close();
+    }
+  }
+
+  private void signalTlsDone(boolean success, Throwable cause) {
+    tlsHandshakeSuccess = success;
+    tlsHandshakeFailureCause = cause;
+    if (tlsHandshakeDone != null) {
+      tlsHandshakeDone.countDown();
+    }
+  }
+
+  boolean isTlsHandshakeSuccess() {
+    return tlsHandshakeSuccess;
+  }
+
+  Throwable getTlsHandshakeFailureCause() {
+    return tlsHandshakeFailureCause;
   }
 
   private HttpRequest getConnectRequest() {

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolHttpConnectChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolHttpConnectChainedProxyTest.java
@@ -1,0 +1,233 @@
+package org.littleshoot.proxy.haproxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.ReferenceCountUtil;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.littleshoot.proxy.ChainedProxyAdapter;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+/**
+ * With {@code sendProxyProtocol=true} and an HTTP CONNECT chained proxy, the PROXY header must be
+ * tunnelled to the final server (first bytes after the CONNECT handshake), not sent to the
+ * intermediate proxy ahead of the CONNECT.
+ *
+ * <p>Topology: raw client → downstream LittleProxy → intermediate HTTP CONNECT proxy → final
+ * server.
+ */
+@Tag("slow-test")
+public final class ProxyProtocolHttpConnectChainedProxyTest {
+
+  private EventLoopGroup bossGroup;
+  private EventLoopGroup workerGroup;
+  private HttpProxyServer downstreamProxy;
+  private Socket clientSocket;
+
+  private final AtomicReference<String> intermediateFirstBytes = new AtomicReference<>();
+  private final AtomicReference<String> finalServerFirstBytes = new AtomicReference<>();
+  private final CountDownLatch intermediateReceivedConnect = new CountDownLatch(1);
+  private final CountDownLatch finalServerReceivedData = new CountDownLatch(1);
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (clientSocket != null) {
+      clientSocket.close();
+    }
+    if (downstreamProxy != null) {
+      downstreamProxy.abort();
+    }
+    if (bossGroup != null) {
+      bossGroup.shutdownGracefully();
+    }
+    if (workerGroup != null) {
+      workerGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  void proxyProtocolHeaderIsTunnelledToFinalServerNotIntermediateProxy() throws Exception {
+    bossGroup = new NioEventLoopGroup(1);
+    workerGroup = new NioEventLoopGroup();
+
+    int finalServerPort = startFinalServer();
+    int intermediatePort = startIntermediateConnectProxy(finalServerPort);
+    int downstreamPort = startDownstreamProxy(intermediatePort);
+
+    sendConnectThroughDownstream(downstreamPort, finalServerPort);
+
+    assertThat(intermediateReceivedConnect.await(5, TimeUnit.SECONDS))
+        .as("intermediate proxy should receive the CONNECT")
+        .isTrue();
+    assertThat(finalServerReceivedData.await(5, TimeUnit.SECONDS))
+        .as("final server should receive tunnelled bytes")
+        .isTrue();
+
+    assertThat(intermediateFirstBytes.get())
+        .as("intermediate HTTP proxy must see a plain CONNECT as its first bytes")
+        .startsWith("CONNECT");
+    assertThat(intermediateFirstBytes.get())
+        .as("intermediate HTTP proxy must NOT receive a PROXY header")
+        .doesNotContain("PROXY TCP");
+
+    assertThat(finalServerFirstBytes.get())
+        .as("final server must receive the PROXY protocol header as the first tunnelled bytes")
+        .startsWith("PROXY TCP");
+  }
+
+  /** Captures the first bytes the ultimate destination receives. */
+  private int startFinalServer() {
+    ServerBootstrap b = new ServerBootstrap();
+    b.group(bossGroup, workerGroup)
+        .channel(NioServerSocketChannel.class)
+        .childHandler(
+            new ChannelInitializer<SocketChannel>() {
+              @Override
+              protected void initChannel(SocketChannel ch) {
+                ch.pipeline()
+                    .addLast(
+                        new ChannelInboundHandlerAdapter() {
+                          @Override
+                          public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            ByteBuf buf = (ByteBuf) msg;
+                            finalServerFirstBytes.compareAndSet(
+                                null, buf.toString(StandardCharsets.US_ASCII));
+                            buf.release();
+                            finalServerReceivedData.countDown();
+                          }
+                        });
+              }
+            });
+    Channel ch = b.bind(0).syncUninterruptibly().channel();
+    return ((InetSocketAddress) ch.localAddress()).getPort();
+  }
+
+  /**
+   * Minimal HTTP CONNECT proxy: records its first bytes, answers 200, then relays to the final
+   * server.
+   */
+  private int startIntermediateConnectProxy(int finalServerPort) {
+    ServerBootstrap b = new ServerBootstrap();
+    b.group(bossGroup, workerGroup)
+        .channel(NioServerSocketChannel.class)
+        .childHandler(
+            new ChannelInitializer<SocketChannel>() {
+              @Override
+              protected void initChannel(SocketChannel ch) {
+                ch.pipeline()
+                    .addLast(
+                        new ChannelInboundHandlerAdapter() {
+                          private volatile Channel outbound;
+                          private boolean connectHandled;
+
+                          @Override
+                          public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            ByteBuf buf = (ByteBuf) msg;
+                            if (!connectHandled) {
+                              connectHandled = true;
+                              intermediateFirstBytes.compareAndSet(
+                                  null, buf.toString(StandardCharsets.US_ASCII));
+                              buf.release();
+                              intermediateReceivedConnect.countDown();
+                              connectToFinalServerThenRespond(ctx, finalServerPort);
+                            } else if (outbound != null) {
+                              outbound.writeAndFlush(msg);
+                            } else {
+                              buf.release();
+                            }
+                          }
+
+                          private void connectToFinalServerThenRespond(
+                              ChannelHandlerContext ctx, int port) {
+                            Bootstrap cb = new Bootstrap();
+                            cb.group(workerGroup)
+                                .channel(NioSocketChannel.class)
+                                .handler(
+                                    new ChannelInboundHandlerAdapter() {
+                                      @Override
+                                      public void channelRead(ChannelHandlerContext c, Object m) {
+                                        ReferenceCountUtil.release(m);
+                                      }
+                                    });
+                            cb.connect("localhost", port)
+                                .addListener(
+                                    (ChannelFutureListener)
+                                        f -> {
+                                          if (f.isSuccess()) {
+                                            outbound = f.channel();
+                                            ctx.writeAndFlush(
+                                                Unpooled.copiedBuffer(
+                                                    "HTTP/1.1 200 Connection Established\r\n\r\n",
+                                                    StandardCharsets.US_ASCII));
+                                          } else {
+                                            ctx.close();
+                                          }
+                                        });
+                          }
+                        });
+              }
+            });
+    Channel ch = b.bind(0).syncUninterruptibly().channel();
+    return ((InetSocketAddress) ch.localAddress()).getPort();
+  }
+
+  private int startDownstreamProxy(int intermediatePort) {
+    downstreamProxy =
+        DefaultHttpProxyServer.bootstrap()
+            .withName("Downstream")
+            .withPort(0)
+            .withSendProxyProtocol(true)
+            .withChainProxyManager(
+                (httpRequest, chainedProxies, clientDetails) ->
+                    chainedProxies.add(
+                        new ChainedProxyAdapter() {
+                          @Override
+                          public InetSocketAddress getChainedProxyAddress() {
+                            return new InetSocketAddress("localhost", intermediatePort);
+                          }
+                        }))
+            .start();
+    return downstreamProxy.getListenAddress().getPort();
+  }
+
+  private void sendConnectThroughDownstream(int downstreamPort, int finalServerPort)
+      throws Exception {
+    clientSocket = new Socket("localhost", downstreamPort);
+    clientSocket.setSoTimeout(5000);
+    OutputStream out = clientSocket.getOutputStream();
+    String connect =
+        "CONNECT localhost:"
+            + finalServerPort
+            + " HTTP/1.1\r\nHost: localhost:"
+            + finalServerPort
+            + "\r\n\r\n";
+    out.write(connect.getBytes(StandardCharsets.US_ASCII));
+    out.flush();
+    // Discard the CONNECT response; the socket stays open until tearDown so the tunnel lives while
+    // the PROXY header propagates.
+    clientSocket.getInputStream().read(new byte[1024]);
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolOrderTest.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolOrderTest.java
@@ -1,0 +1,29 @@
+package org.littleshoot.proxy.haproxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that LittleProxy's inbound pipeline decodes the PROXY protocol header performing the TLS
+ * handshake.
+ */
+public final class ProxyProtocolOrderTest extends BaseProxyProtocolTest {
+
+  @Override
+  protected boolean useTlsInbound() {
+    return true;
+  }
+
+  @Test
+  void proxyProtocolIsDecodedBeforeTlsOnInbound() throws Exception {
+    setup(true, true);
+
+    HAProxyMessage relayed = getRelayedHaProxyMessage();
+
+    assertThat(relayed).as("PROXY protocol message should be decoded even with TLS").isNotNull();
+    assertThat(relayed.sourceAddress()).isEqualTo(SOURCE_ADDRESS);
+    assertThat(relayed.destinationAddress()).isEqualTo(DESTINATION_ADDRESS);
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolServerHandler.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolServerHandler.java
@@ -3,19 +3,28 @@ package org.littleshoot.proxy.haproxy;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class ProxyProtocolServerHandler extends ChannelInboundHandlerAdapter {
 
-  private HAProxyMessage haProxyMessage;
+  private final CountDownLatch messageLatch = new CountDownLatch(1);
+  private volatile HAProxyMessage haProxyMessage;
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
     if (msg instanceof HAProxyMessage) {
       haProxyMessage = (HAProxyMessage) msg;
+      messageLatch.countDown();
     }
   }
 
-  HAProxyMessage getHaProxyMessage() {
+  /**
+   * Waits up to the given timeout for an HAProxyMessage to arrive. Returns the message, or null if
+   * none arrived within the timeout.
+   */
+  HAProxyMessage awaitHaProxyMessage(long timeout, TimeUnit unit) throws InterruptedException {
+    messageLatch.await(timeout, unit);
     return haProxyMessage;
   }
 }

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolTest.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolTest.java
@@ -4,7 +4,17 @@ import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.Test;
+import org.littleshoot.proxy.ActivityTrackerAdapter;
+import org.littleshoot.proxy.ChainedProxyAdapter;
+import org.littleshoot.proxy.FlowContext;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
 
 public final class ProxyProtocolTest extends BaseProxyProtocolTest {
 
@@ -13,6 +23,42 @@ public final class ProxyProtocolTest extends BaseProxyProtocolTest {
   private static final boolean SEND_PROXY = true;
   private static final boolean DO_NOT_ACCEPT_PROXY = false;
   private static final boolean DO_NOT_SEND_PROXY = false;
+
+  private final AtomicInteger clientConnectedCount = new AtomicInteger();
+  private final AtomicReference<InetSocketAddress> trackerClientAddress = new AtomicReference<>();
+  private final AtomicReference<InetSocketAddress> chainedProxyClientAddress =
+      new AtomicReference<>();
+  private final CountDownLatch clientDisconnectedLatch = new CountDownLatch(1);
+
+  /** Set by a test before {@code setup(...)} to also capture the chained-routing address. */
+  private volatile boolean captureChainedProxyClientDetails;
+
+  @Override
+  protected void customizeProxyServer(HttpProxyServerBootstrap builder) {
+    // Observational tracker; harmless for the header-relay tests that ignore these captures.
+    builder.plusActivityTracker(
+        new ActivityTrackerAdapter() {
+          @Override
+          public void clientConnected(FlowContext flowContext) {
+            clientConnectedCount.incrementAndGet();
+            trackerClientAddress.set(flowContext.getClientAddress());
+          }
+
+          @Override
+          public void clientDisconnected(FlowContext flowContext, SSLSession sslSession) {
+            clientDisconnectedLatch.countDown();
+          }
+        });
+
+    if (captureChainedProxyClientDetails) {
+      // Capture the routing address, then fall back to direct so the flow completes.
+      builder.withChainProxyManager(
+          (httpRequest, chainedProxies, clientDetails) -> {
+            chainedProxyClientAddress.set(clientDetails.getClientAddress());
+            chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
+          });
+    }
+  }
 
   @Test
   public void canRelayProxyProtocolHeader() throws Exception {
@@ -40,5 +86,52 @@ public final class ProxyProtocolTest extends BaseProxyProtocolTest {
     setup(ACCEPT_PROXY, DO_NOT_SEND_PROXY);
     HAProxyMessage haProxyMessage = getRelayedHaProxyMessage();
     assertThat(haProxyMessage).isNull();
+  }
+
+  /** The PROXY header source address is surfaced to both the tracker and chained routing. */
+  @Test
+  public void surfacesRealClientAddressFromProxyProtocolHeader() throws Exception {
+    captureChainedProxyClientDetails = true;
+    setup(ACCEPT_PROXY, SEND_PROXY);
+
+    assertThat(clientDisconnectedLatch.await(5, TimeUnit.SECONDS))
+        .as("client should connect and then disconnect within the timeout")
+        .isTrue();
+
+    assertThat(trackerClientAddress.get())
+        .as("ActivityTracker should see the PROXY header source address")
+        .isNotNull();
+    assertThat(trackerClientAddress.get().getHostString()).isEqualTo(SOURCE_ADDRESS);
+    assertThat(trackerClientAddress.get().getPort()).isEqualTo(Integer.parseInt(SOURCE_PORT));
+
+    assertThat(chainedProxyClientAddress.get())
+        .as("ChainedProxyManager (ClientDetails) should see the PROXY header source address")
+        .isNotNull();
+    assertThat(chainedProxyClientAddress.get().getHostString()).isEqualTo(SOURCE_ADDRESS);
+    assertThat(chainedProxyClientAddress.get().getPort()).isEqualTo(Integer.parseInt(SOURCE_PORT));
+  }
+
+  /**
+   * With no PROXY header, {@code clientConnected} still fires once, from the first request, with
+   * the TCP peer address.
+   */
+  @Test
+  public void clientConnectedFiresOnceWithTcpPeerWhenNoProxyHeader() throws Exception {
+    setup(DO_NOT_ACCEPT_PROXY, DO_NOT_SEND_PROXY);
+
+    assertThat(clientDisconnectedLatch.await(5, TimeUnit.SECONDS))
+        .as("client should connect and then disconnect within the timeout")
+        .isTrue();
+
+    assertThat(clientConnectedCount.get())
+        .as("clientConnected must fire exactly once across the connection lifecycle")
+        .isEqualTo(1);
+
+    assertThat(trackerClientAddress.get())
+        .as("clientConnected should carry the TCP peer address when no PROXY header is present")
+        .isNotNull();
+    assertThat(trackerClientAddress.get().getAddress().isLoopbackAddress())
+        .as("client connected over loopback, so the reported address should be a loopback address")
+        .isTrue();
   }
 }

--- a/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolWrongOrderTest.java
+++ b/src/test/java/org/littleshoot/proxy/haproxy/ProxyProtocolWrongOrderTest.java
@@ -1,0 +1,49 @@
+package org.littleshoot.proxy.haproxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Negative test: when the PROXY protocol header is sent after the TLS handshake (i.e. encrypted
+ * inside the tunnel), the proxy must NOT successfully decode it.
+ */
+public final class ProxyProtocolWrongOrderTest extends BaseProxyProtocolTest {
+
+  @Override
+  protected boolean useTlsInbound() {
+    return true;
+  }
+
+  @Override
+  protected boolean sendProxyHeaderBeforeTls() {
+    return false;
+  }
+
+  @Test
+  @Tag("slow-test")
+  void proxyProtocolInsideTlsTunnelIsNotDecoded() throws Exception {
+    setup(true, true);
+
+    boolean tlsCompleted = clientTlsHandshakeDone.await(5, TimeUnit.SECONDS);
+    assertThat(tlsCompleted)
+        .as("TLS handshake should complete or fail within the timeout")
+        .isTrue();
+    if (isClientTlsHandshakeSuccess()) {
+      assertThat(getRelayedHaProxyMessage())
+          .as("PROXY header sent inside TLS must not be decoded")
+          .isNull();
+    } else {
+      assertThat(getClientTlsHandshakeFailureCause())
+          .as("TLS failure should expose a cause")
+          .isNotNull();
+      assertThat(isClientTlsHandshakeSuccess())
+          .as(
+              "TLS should fail when PROXY header is not sent before TLS. " + "Cause: %s",
+              getClientTlsHandshakeFailureCause())
+          .isFalse();
+    }
+  }
+}

--- a/src/test/java/org/littleshoot/proxy/impl/ClientToProxyConnectionTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ClientToProxyConnectionTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.ActivityTracker;
@@ -45,6 +46,13 @@ class ClientToProxyConnectionTest {
     logField.setAccessible(true);
     logField.set(mockConnection, mockLogger);
 
+    // The mock bypasses the constructor; set the guard to true so recordDisconnected's fallback
+    // recordClientConnected() is a no-op here.
+    Field clientConnectedRecordedField =
+        ClientToProxyConnection.class.getDeclaredField("clientConnectedRecorded");
+    clientConnectedRecordedField.setAccessible(true);
+    clientConnectedRecordedField.set(mockConnection, new AtomicBoolean(true));
+
     Method recordMethod =
         ClientToProxyConnection.class.getDeclaredMethod("recordClientDisconnected");
     recordMethod.setAccessible(true);
@@ -77,6 +85,13 @@ class ClientToProxyConnectionTest {
     Field logField = ProxyConnection.class.getDeclaredField("LOG");
     logField.setAccessible(true);
     logField.set(mockConnection, mockLogger);
+
+    // The mock bypasses the constructor; set the guard to true so recordDisconnected's fallback
+    // recordClientConnected() is a no-op here.
+    Field clientConnectedRecordedField =
+        ClientToProxyConnection.class.getDeclaredField("clientConnectedRecorded");
+    clientConnectedRecordedField.setAccessible(true);
+    clientConnectedRecordedField.set(mockConnection, new AtomicBoolean(true));
 
     Method recordMethod =
         ClientToProxyConnection.class.getDeclaredMethod("recordClientDisconnected");

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionTest.java
@@ -5,20 +5,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
-import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
+import javax.net.ssl.SSLEngine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.ActivityTracker;
+import org.littleshoot.proxy.ChainedProxy;
+import org.littleshoot.proxy.ChainedProxyManager;
+import org.littleshoot.proxy.ChainedProxyType;
 import org.littleshoot.proxy.FlowContext;
 import org.littleshoot.proxy.FullFlowContext;
 import org.littleshoot.proxy.HostResolver;
 import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.TransportProtocol;
 
 class ProxyToServerConnectionTest {
 
@@ -95,13 +100,6 @@ class ProxyToServerConnectionTest {
     verify(mockClientConnection).clearFlowContextForServerConnection(connection);
   }
 
-  private void invokeRecordMethod(ProxyToServerConnection connection, String methodName)
-      throws Exception {
-    Method method = ProxyToServerConnection.class.getDeclaredMethod(methodName);
-    method.setAccessible(true);
-    method.invoke(connection);
-  }
-
   @Test
   @DisplayName("serverConnected should notify all trackers even if one throws")
   void serverConnectedShouldNotifyAllTrackersEvenIfOneThrows() throws Exception {
@@ -115,7 +113,7 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    invokeRecordMethod(connection, "recordServerConnected");
+    connection.recordServerConnected();
 
     verify(throwingTracker).serverConnected(any(), any());
     verify(succeedingTracker).serverConnected(any(), any());
@@ -135,7 +133,7 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    invokeRecordMethod(connection, "recordServerDisconnected");
+    connection.recordServerDisconnected();
 
     verify(throwingTracker).serverDisconnected(any(), any());
     verify(succeedingTracker).serverDisconnected(any(), any());
@@ -155,7 +153,7 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    invokeRecordMethod(connection, "recordConnectionSaturated");
+    connection.recordConnectionSaturated();
 
     verify(throwingTracker).connectionSaturated(any());
     verify(succeedingTracker).connectionSaturated(any());
@@ -172,7 +170,7 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    invokeRecordMethod(connection, "recordConnectionWritable");
+    connection.recordConnectionWritable();
 
     verify(throwingTracker).connectionWritable(any());
     verify(succeedingTracker).connectionWritable(any());
@@ -189,10 +187,39 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    invokeRecordMethod(connection, "recordConnectionTimedOut");
+    connection.recordConnectionTimedOut();
 
     verify(throwingTracker).connectionTimedOut(any());
     verify(succeedingTracker).connectionTimedOut(any());
+  }
+
+  @Test
+  @DisplayName("encrypted chained proxies should prefer peer-aware SSL engines")
+  void encryptedChainedProxiesShouldPreferPeerAwareSslEngines() throws Exception {
+    ChainedProxy chainedProxy = mock();
+    SSLEngine peerAwareEngine = mock();
+    when(chainedProxy.newSslEngine("127.0.0.1", 9443)).thenReturn(peerAwareEngine);
+    ProxyToServerConnection connection = createConnectionWithChainedProxy(chainedProxy);
+
+    assertThat(connection.newChainedProxySslEngine()).isSameAs(peerAwareEngine);
+
+    verify(chainedProxy).newSslEngine("127.0.0.1", 9443);
+    verify(chainedProxy, never()).newSslEngine();
+  }
+
+  @Test
+  @DisplayName("encrypted chained proxies should fall back to legacy SSL engines")
+  void encryptedChainedProxiesShouldFallBackToLegacySslEngines() throws Exception {
+    ChainedProxy chainedProxy = mock();
+    SSLEngine legacyEngine = mock();
+    when(chainedProxy.newSslEngine("127.0.0.1", 9443)).thenReturn(null);
+    when(chainedProxy.newSslEngine()).thenReturn(legacyEngine);
+    ProxyToServerConnection connection = createConnectionWithChainedProxy(chainedProxy);
+
+    assertThat(connection.newChainedProxySslEngine()).isSameAs(legacyEngine);
+
+    verify(chainedProxy).newSslEngine("127.0.0.1", 9443);
+    verify(chainedProxy).newSslEngine();
   }
 
   @Test
@@ -208,13 +235,29 @@ class ProxyToServerConnectionTest {
         createConnection(Arrays.asList(throwingTracker, succeedingTracker));
     assertThat(connection).isNotNull();
 
-    Method method =
-        ProxyToServerConnection.class.getDeclaredMethod(
-            "recordConnectionExceptionCaught", Throwable.class);
-    method.setAccessible(true);
-    method.invoke(connection, new RuntimeException("Test cause"));
+    connection.recordConnectionExceptionCaught(new RuntimeException("Test cause"));
 
     verify(throwingTracker).connectionExceptionCaught(any(), any());
     verify(succeedingTracker).connectionExceptionCaught(any(), any());
+  }
+
+  private ProxyToServerConnection createConnectionWithChainedProxy(ChainedProxy chainedProxy)
+      throws UnknownHostException {
+    ChainedProxyManager chainedProxyManager = mock();
+    when(mockProxyServer.getChainProxyManager()).thenReturn(chainedProxyManager);
+    doAnswer(
+            invocation -> {
+              invocation.<Queue<ChainedProxy>>getArgument(1).add(chainedProxy);
+              return null;
+            })
+        .when(chainedProxyManager)
+        .lookupChainedProxies(any(), any(), any());
+
+    when(chainedProxy.getTransportProtocol()).thenReturn(TransportProtocol.TCP);
+    when(chainedProxy.getChainedProxyType()).thenReturn(ChainedProxyType.HTTP);
+    when(chainedProxy.getChainedProxyAddress())
+        .thenReturn(new InetSocketAddress("127.0.0.1", 9443));
+
+    return createConnection(Collections.emptyList());
   }
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 junit.jupiter.extensions.autodetection.enabled=true
-junit.jupiter.execution.timeout.default=15
+junit.jupiter.execution.timeout.default=30s
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
Fix proxy protocol order decoding for inbound/ outbound requests

Remove proxy protocol logic in ConnectionFlow which order of proxy protocol sending was wrong

Fix ProxyToServerConnection to correctly send the outbound proxy protocol message when enabled with correct client address and remote address as per rfc 

Fix flow context when we have relay proxy message to capture the information from it Add ProxyProtocolOrderTest to test that the proxy correctly handles PROXY protocol before TLS. If order of handlers in ClientToProxyConnection is wrong, test of ProxyProtocolOrderTest will fail.

Add ProxyProtocolWrongOrderTest to test that the proxy correctly handles incorrect order of PROXY PROTOCOL after TLS.

Increase junit timeout since when ran parallel tests might class and not be able to allocate resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PROXY protocol support with configurable ordering relative to TLS (can decode before TLS).
  * Client IP detection now prefers PROXY header values when present.
  * Conditional sending of PROXY headers to upstream servers when enabled.

* **Tests**
  * Added positive and negative tests for PROXY/TLS ordering.
  * Improved test determinism (centralized cleanup, ordered tests) and increased default test timeout to 30s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->