### PR TITLE
Fix unsupported `com.lmax.disruptor` scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
             <version>${disruptor.version}</version>
-            <scope>optional</scope>
+            <optional>true</optional>
         </dependency>
 
         <!-- Optional DNS dependencies -->


### PR DESCRIPTION
This PR fixes the following Maven warning:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.github.littleproxy:littleproxy:jar:2.7.0
[WARNING] 'dependencies.dependency.scope' for com.lmax:disruptor:jar must be one of [provided, compile, runtime, test, system] but is 'optional'. @ line 272, column 20
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

I'm running `Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)`.  

The same warning is also printed in CI build, for example: https://github.com/LittleProxy/LittleProxy/actions/runs/25089284084/job/73511665555#step:6:143. 

Today, Maven falls back to `compile` scope when the value is invalid, so disruptor leaks onto downstream consumers' compile classpaths transitively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed build configuration to properly specify optional dependency metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->