### PR TITLE
Fix duplicate test-compile execution running at Java 11 instead of 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
                     </configuration>
                     <executions>
                         <execution>
-                            <id>compile-tests-with-java17</id>
+                            <id>default-testCompile</id>
                             <phase>test-compile</phase>
                             <goals>
                                 <goal>testCompile</goal>


### PR DESCRIPTION
## Summary
- `mvn test` was failing with `pattern matching in instanceof is not supported in -source 11`, even though tests are meant to compile with Java 17.
- Root cause: the `maven-compiler-plugin`'s custom `testCompile` execution used a distinct id (`compile-tests-with-java17`) instead of overriding the implicit `default-testCompile` binding that Maven's default lifecycle already provides. Both executions ran in the `test-compile` phase — the implicit one first, using the plugin's top-level `release=${java.version}` (11) — and it failed before the release-17 execution ever got a chance to run.
- Fix: rename the execution id to `default-testCompile` so it overrides the default binding instead of running alongside it.

## Test plan
- [x] `mvn test -Dtest=Socks5ChainedProxyAuthenticationTest` — confirmed only one `testCompile` execution now runs, at `release 17`, and the build succeeds
- [x] `mvn package -Psmoke-test` — full smoke-test build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)