### PR TITLE
Fix/pr717 coderabbitai bugs

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -391,6 +391,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
   @Override
   protected void readHTTPChunk(HttpContent chunk) {
+    if (currentServerConnection == null) {
+      LOG.warn("Cannot forward HTTP chunk: no server connection");
+      return;
+    }
     currentFilters.clientToProxyRequest(chunk);
     currentFilters.proxyToServerRequest(chunk);
 
@@ -399,6 +403,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
   @Override
   protected void readRaw(ByteBuf buf) {
+    if (currentServerConnection == null) {
+      LOG.warn("Cannot forward raw data: no server connection");
+      return;
+    }
     currentServerConnection.write(buf);
   }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -729,9 +729,15 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
           }
         }
 
-        connectionFlow
-            .then(clientConnection.RespondCONNECTSuccessful)
-            .then(serverConnection.MitmEncryptClientChannel);
+        if (!disableSslForNonTls) {
+          connectionFlow
+              .then(clientConnection.RespondCONNECTSuccessful)
+              .then(serverConnection.MitmEncryptClientChannel);
+        } else {
+          // For non-SSL servers, just respond CONNECT successful.
+          // ClientToProxyConnection will call encryptForMitm() if client sends TLS.
+          connectionFlow.then(clientConnection.RespondCONNECTSuccessful);
+        }
       } else {
         connectionFlow
             .then(serverConnection.StartTunneling)
@@ -1371,14 +1377,15 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     // Check for patterns that indicate the server doesn't speak SSL
     String message = cause.getMessage();
     if (message != null) {
+      String lowerMessage = message.toLowerCase(java.util.Locale.ROOT);
       // "Remote host terminated the handshake" - server doesn't support SSL
       // "end of file" - server closed connection unexpectedly
       // "connection reset" - server doesn't speak SSL
       // "not an SSL/TLS record" - server sent HTTP response to SSL handshake
-      if (message.contains("Remote host terminated")
-          || message.contains("end of file")
-          || message.contains("connection reset")
-          || message.contains("not an SSL")) {
+      if (lowerMessage.contains("remote host terminated")
+          || lowerMessage.contains("end of file")
+          || lowerMessage.contains("connection reset")
+          || lowerMessage.contains("not an ssl")) {
         return true;
       }
     }

--- a/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
+++ b/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
@@ -151,6 +151,10 @@ public final class EndToEndStoppingTest {
     log.info("OS: {} (is windows: {})", os, os.contains("win"));
     assumeThat(os.contains("win")).isFalse();
 
+    assumeThat(isChromeDriverAvailable())
+        .as("Chrome/chromedriver must be installed to run WebDriver tests")
+        .isTrue();
+
     HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap().withPort(0).start();
 
     try {
@@ -187,5 +191,23 @@ public final class EndToEndStoppingTest {
     } finally {
       driver.quit();
     }
+  }
+
+  private static boolean isChromeDriverAvailable() {
+    String[] commands = {"chromedriver", "google-chrome", "google-chrome-stable", "chrome"};
+    for (String cmd : commands) {
+      try {
+        Process p = new ProcessBuilder("which", cmd).redirectErrorStream(true).start();
+        int exitCode = p.waitFor();
+        if (exitCode == 0) {
+          log.info("Found browser/driver: {}", cmd);
+          return true;
+        }
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    log.warn("No Chrome/chromedriver found on PATH - WebDriver tests will be skipped");
+    return false;
   }
 }

--- a/src/test/java/org/littleshoot/proxy/Issue71NonSslConnectTest.java
+++ b/src/test/java/org/littleshoot/proxy/Issue71NonSslConnectTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.extras.TestMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
@@ -75,6 +76,7 @@ class Issue71NonSslConnectTest {
    * request to the proxy, but the target websocket server doesn't use SSL.
    */
   @Test
+  @Tag("slow-test")
   void testConnectRequestToNonSslServerInMitmMode() throws Exception {
     // Set up MITM proxy
     proxyServer =

--- a/src/test/java/org/littleshoot/proxy/Issue71NonSslConnectTest.java
+++ b/src/test/java/org/littleshoot/proxy/Issue71NonSslConnectTest.java
@@ -141,10 +141,56 @@ class Issue71NonSslConnectTest {
                 + "Got 502 Bad Gateway because the SSL handshake failed with a non-SSL server.");
       }
 
-      // If we get here, the fix is in place
+      // If we get here, the CONNECT was successful
       assertThat(responseStr)
           .as("Should receive successful CONNECT response (200)")
           .contains("200");
+
+      // Now send a plain HTTP request through the tunnel to verify end-to-end data flow.
+      // This exposes Bug 1 (NPE in MitmEncryptClientChannel when disableSslForNonTls=true)
+      // and Bug 2 (client channel incorrectly encrypted for MITM while server is plain text).
+      String httpRequest =
+          "GET / HTTP/1.1\r\n" + "Host: 127.0.0.1:" + webServerPort + "\r\n" + "\r\n";
+      socket.getOutputStream().write(httpRequest.getBytes(StandardCharsets.US_ASCII));
+      socket.getOutputStream().flush();
+
+      StringBuilder tunnelResponse = new StringBuilder();
+      try {
+        while ((read = socket.getInputStream().read(buffer)) != -1) {
+          tunnelResponse.append(new String(buffer, 0, read, StandardCharsets.US_ASCII));
+          if (tunnelResponse.toString().contains("\r\n\r\n")) {
+            break;
+          }
+        }
+      } catch (IOException e) {
+        LOG.error("IOException reading tunneled response", e);
+        String exceptionMessage = e.getMessage();
+        if (exceptionMessage != null
+            && (exceptionMessage.toLowerCase().contains("ssl")
+                || exceptionMessage.toLowerCase().contains("handshake")
+                || exceptionMessage.toLowerCase().contains("connection reset"))) {
+          fail(
+              "Bug #71 still present: Tunnel data flow failed because proxy encrypted client channel "
+                  + "for MITM while server is plain text. Exception: "
+                  + e.getMessage());
+        }
+        throw e;
+      }
+
+      LOG.info("Tunneled HTTP response: {}", tunnelResponse);
+
+      String tunnelResponseStr = tunnelResponse.toString();
+      assertThat(tunnelResponseStr)
+          .as(
+              "Tunneled HTTP request should return a valid response from the non-SSL server, "
+                  + "not a 502 Bad Gateway or SSL error")
+          .doesNotContain("502")
+          .doesNotContain("Bad Gateway");
+
+      // Verify we got actual HTTP content from the upstream server
+      assertThat(tunnelResponseStr)
+          .as("Tunneled response should contain HTTP status line")
+          .contains("HTTP/");
     }
   }
 }

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -12,6 +14,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLProtocolException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -259,5 +264,139 @@ class ProxyToServerConnectionTest {
         .thenReturn(new InetSocketAddress("127.0.0.1", 9443));
 
     return createConnection(Collections.emptyList());
+  }
+
+  /**
+   * Helper to invoke the private {@code shouldRetryWithoutSsl} method via reflection.
+   *
+   * @param connection the connection instance
+   * @param cause the exception to test
+   * @return true if the method says to retry without SSL
+   */
+  private boolean invokeShouldRetryWithoutSsl(ProxyToServerConnection connection, Throwable cause)
+      throws Exception {
+    Method method =
+        ProxyToServerConnection.class.getDeclaredMethod("shouldRetryWithoutSsl", Throwable.class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(connection, cause);
+  }
+
+  /**
+   * Helper to set the private {@code disableSslForNonTls} field via reflection.
+   *
+   * @param connection the connection instance
+   * @param value the value to set
+   */
+  private void setDisableSslForNonTls(ProxyToServerConnection connection, boolean value)
+      throws Exception {
+    Field field = ProxyToServerConnection.class.getDeclaredField("disableSslForNonTls");
+    field.setAccessible(true);
+    field.setBoolean(connection, value);
+  }
+
+  @Test
+  @DisplayName(
+      "shouldRetryWithoutSsl should return true for SSLHandshakeException with matching message")
+  void shouldRetryWithoutSslReturnsTrueForSslHandshakeException() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    SSLHandshakeException cause = new SSLHandshakeException("Remote host terminated the handshake");
+    assertThat(invokeShouldRetryWithoutSsl(connection, cause)).isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "shouldRetryWithoutSsl should return true for SSLProtocolException with matching message")
+  void shouldRetryWithoutSslReturnsTrueForSslProtocolException() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    SSLProtocolException cause = new SSLProtocolException("end of file");
+    assertThat(invokeShouldRetryWithoutSsl(connection, cause)).isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "shouldRetryWithoutSsl should return true for generic SSLException with matching message")
+  void shouldRetryWithoutSslReturnsTrueForGenericSslException() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    SSLException cause = new SSLException("not an SSL/TLS record");
+    assertThat(invokeShouldRetryWithoutSsl(connection, cause)).isTrue();
+  }
+
+  @Test
+  @DisplayName("shouldRetryWithoutSsl should handle case-insensitive error messages (Bug 3)")
+  void shouldRetryWithoutSslHandlesCaseInsensitiveMessages() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    // Uppercase variant - should match even though current code uses case-sensitive contains
+    SSLHandshakeException upperCase =
+        new SSLHandshakeException("Remote Host Terminated The Handshake");
+    assertThat(invokeShouldRetryWithoutSsl(connection, upperCase))
+        .as(
+            "shouldRetryWithoutSsl should match 'Remote Host Terminated' (mixed case) - "
+                + "Bug 3: case-sensitive matching is fragile across JVM implementations")
+        .isTrue();
+
+    // Lowercase variant
+    SSLHandshakeException lowerCase =
+        new SSLHandshakeException("remote host terminated the handshake");
+    assertThat(invokeShouldRetryWithoutSsl(connection, lowerCase))
+        .as("shouldRetryWithoutSsl should match 'remote host terminated' (lowercase)")
+        .isTrue();
+
+    // "Connection Reset" vs "connection reset"
+    SSLException connectionResetUpper = new SSLException("Connection reset");
+    assertThat(invokeShouldRetryWithoutSsl(connection, connectionResetUpper))
+        .as(
+            "shouldRetryWithoutSsl should match 'Connection reset' (capitalized) - "
+                + "Bug 3: some JVMs capitalize this message")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("shouldRetryWithoutSsl should return false for null cause")
+  void shouldRetryWithoutSslReturnsFalseForNullCause() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    assertThat(invokeShouldRetryWithoutSsl(connection, null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("shouldRetryWithoutSsl should return false for non-SSL exceptions")
+  void shouldRetryWithoutSslReturnsFalseForNonSslExceptions() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    assertThat(invokeShouldRetryWithoutSsl(connection, new RuntimeException("some error")))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("shouldRetryWithoutSsl should return false when already retried without SSL")
+  void shouldRetryWithoutSslReturnsFalseWhenAlreadyRetried() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    setDisableSslForNonTls(connection, true);
+
+    SSLHandshakeException cause = new SSLHandshakeException("Remote host terminated the handshake");
+    assertThat(invokeShouldRetryWithoutSsl(connection, cause)).isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "shouldRetryWithoutSsl should return false for SSL exceptions with non-matching messages")
+  void shouldRetryWithoutSslReturnsFalseForNonMatchingMessages() throws Exception {
+    ProxyToServerConnection connection = createConnection(Collections.emptyList());
+    assertThat(connection).isNotNull();
+
+    SSLHandshakeException cause = new SSLHandshakeException("certificate expired");
+    assertThat(invokeShouldRetryWithoutSsl(connection, cause)).isFalse();
   }
 }


### PR DESCRIPTION
## Fix bugs in MITM non-SSL CONNECT handling from PR #717 review

### Summary

Fixes 4 bugs identified by CodeRabbit review on [PR #717](https://github.com/LittleProxy/LittleProxy/pull/717) (issue [#71](https://github.com/LittleProxy/LittleProxy/issues/71)), plus adds missing test coverage and skips a flaky WebDriver test on hosts without Chrome.

### Bugs fixed

**Critical — NPE and broken non-SSL tunnels** (`ProxyToServerConnection.java`)

When a CONNECT request targets a non-SSL server (e.g. `ws://`), the proxy retries without SSL (`disableSslForNonTls=true`), correctly skipping the upstream `EncryptChannel`. However, `MitmEncryptClientChannel` was unconditionally added to the connection flow, causing:

1. **NullPointerException** — `sslEngine` is `@Nullable` and was never initialized (since `EncryptChannel` was skipped), but `MitmEncryptClientChannel.execute()` calls `sslEngine.getSession()`.
2. **Client channel incorrectly encrypted** — even if the NPE were guarded, the client side would get MITM encryption while the server is plain text, breaking all tunneled data (e.g. websocket frames).

Fix: `MitmEncryptClientChannel` is now only added when `disableSslForNonTls` is `false`. For non-SSL servers, only `RespondCONNECTSuccessful` is added; `ClientToProxyConnection.encryptForMitm()` handles TLS detection on client bytes if needed.

**Nitpick — case-sensitive error matching** (`ProxyToServerConnection.java`)

`shouldRetryWithoutSsl()` used case-sensitive `contains()` on exception messages. Different JVMs/SSL providers produce varying capitalization (e.g. `"Connection reset"` vs `"connection reset"`). Now uses `message.toLowerCase(Locale.ROOT)` before matching.

**Nitpick — missing null checks** (`ClientToProxyConnection.java`)

`readRaw()` and `readHTTPChunk()` accessed `currentServerConnection` without null checks. Added defensive guards.

### Tests added/modified

| Test | Change |
|------|--------|
| `Issue71NonSslConnectTest` | Extended to send an HTTP request through the tunnel and verify the upstream returns a valid response — previously only checked the CONNECT `200` response code |
| `ProxyToServerConnectionTest` | 8 new tests for `shouldRetryWithoutSsl`: case-insensitive matching, null cause, non-SSL exceptions, already-retried guard, non-matching messages |
| `EndToEndStoppingTest.testWithWebDriver` | Now skips with a clear message when Chrome/chromedriver is not installed, instead of timing out after 60s |

### Test results

- **Before fix**: 2 tests failed confirming both bugs (empty tunnel response + `NotSslRecordException` in logs; case-sensitive matching returned `false` for mixed-case messages)
- **After fix**: 261/261 smoke tests pass (1 skipped: WebDriver not available)

### Related

- Follow-up to [PR #717](https://github.com/LittleProxy/LittleProxy/pull/717) (issue [#71](https://github.com/LittleProxy/LittleProxy/issues/71))
- Addresses CodeRabbit review findings at [pullrequestreview-4117102895](https://github.com/LittleProxy/LittleProxy/pull/717#pullrequestreview-4117102895)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of CONNECT requests to non-SSL servers in MITM mode, including correct behavior when SSL retries are disabled.
  - Made non-SSL retry detection more reliable by using case-insensitive matching of SSL-related error messages.
  - Prevented potential null-pointer issues by defensively handling inbound HTTP chunked and raw byte data when no upstream connection is available.
  - Strengthened plain HTTP tunnel handling through established non-SSL CONNECT tunnels.

- **Tests**
  - Added end-to-end verification of tunneled plain HTTP responses for non-SSL CONNECT scenarios.
  - Added unit test coverage for SSL retry decision logic, including null, non-SSL, and message-matching cases.
  - Browser-based tests now auto-skip when Chrome/Chromedriver executables aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->