### PR TITLE
Allow SslEngineSource to control client certificate authentication mode

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -315,7 +315,9 @@ abstract class ProxyConnection<I extends HttpObject> extends SimpleChannelInboun
    * Encrypts traffic on this connection with SSL/TLS.
    *
    * @param sslEngine the {@link SSLEngine} for doing the encryption
-   * @param authenticateClients determines whether to authenticate clients or not
+   * @param authenticateClients when {@code true}, client authentication is required; when {@code
+   *     false}, the engine's client-auth configuration is left as-is (see {@link
+   *     #encrypt(ChannelPipeline, SSLEngine, boolean)})
    * @return a Future for when the SSL handshake has completed
    */
   protected Future<Channel> encrypt(SSLEngine sslEngine, boolean authenticateClients) {
@@ -327,7 +329,12 @@ abstract class ProxyConnection<I extends HttpObject> extends SimpleChannelInboun
    *
    * @param pipeline the ChannelPipeline on which to enable encryption
    * @param sslEngine the {@link SSLEngine} for doing the encryption
-   * @param authenticateClients determines whether to authenticate clients or not
+   * @param authenticateClients when {@code true}, client authentication is required ({@link
+   *     SSLEngine#setNeedClientAuth(boolean)}). When {@code false}, the client-authentication
+   *     configuration of the supplied {@link SSLEngine} is left untouched, so callers can opt into
+   *     requesting (but not requiring) a client certificate via their {@link
+   *     org.littleshoot.proxy.SslEngineSource} (for example {@link
+   *     SSLEngine#setWantClientAuth(boolean)} or Netty's {@code ClientAuth.OPTIONAL}).
    * @return a Future for when the SSL handshake has completed
    */
   protected Future<Channel> encrypt(
@@ -335,7 +342,9 @@ abstract class ProxyConnection<I extends HttpObject> extends SimpleChannelInboun
     LOG.debug("Enabling encryption with SSLEngine: {}", sslEngine);
     this.sslEngine = sslEngine;
     sslEngine.setUseClientMode(runsAsSslClient);
-    sslEngine.setNeedClientAuth(authenticateClients);
+    if (authenticateClients) {
+      sslEngine.setNeedClientAuth(true);
+    }
     if (null != channel) {
       channel.config().setAutoRead(true);
     }

--- a/src/test/java/org/littleshoot/proxy/impl/ClientToProxyConnectionTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ClientToProxyConnectionTest.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -7,7 +8,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.List;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.ActivityTracker;
@@ -53,5 +57,51 @@ class ClientToProxyConnectionTest {
     connection.disconnected();
 
     verify(normalTracker).clientDisconnected(connection.flowContext(), null);
+  }
+
+  @Test
+  @DisplayName("encrypt requires a client certificate when authenticateClients is true")
+  void encryptRequiresClientCertificateWhenAuthenticateClientsIsTrue() throws Exception {
+    ClientToProxyConnection connection = createConnection();
+    SSLEngine engine = newServerEngine();
+
+    connection.encrypt(newRealPipeline(), engine, true);
+
+    assertThat(engine.getNeedClientAuth()).isTrue();
+  }
+
+  @Test
+  @DisplayName("encrypt leaves a plain engine unauthenticated when authenticateClients is false")
+  void encryptLeavesPlainEngineUnauthenticatedWhenAuthenticateClientsIsFalse() throws Exception {
+    ClientToProxyConnection connection = createConnection();
+    SSLEngine engine = newServerEngine(); // default engine: neither need nor want
+
+    connection.encrypt(newRealPipeline(), engine, false);
+
+    assertThat(engine.getNeedClientAuth()).isFalse();
+    assertThat(engine.getWantClientAuth()).isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "encrypt preserves setWantClientAuth from the SslEngineSource when authenticateClients is false")
+  void encryptPreservesWantClientAuthWhenAuthenticateClientsIsFalse() throws Exception {
+    ClientToProxyConnection connection = createConnection();
+    SSLEngine engine = newServerEngine();
+    engine.setWantClientAuth(true); // e.g. an engine built with Netty ClientAuth.OPTIONAL
+
+    connection.encrypt(newRealPipeline(), engine, false);
+
+    // Before the fix, encrypt() called setNeedClientAuth(false) here, which cleared this flag.
+    assertThat(engine.getWantClientAuth()).isTrue();
+    assertThat(engine.getNeedClientAuth()).isFalse();
+  }
+
+  private static SSLEngine newServerEngine() throws Exception {
+    return SSLContext.getDefault().createSSLEngine();
+  }
+
+  private static ChannelPipeline newRealPipeline() {
+    return new EmbeddedChannel().pipeline();
   }
 }


### PR DESCRIPTION
This PR lets callers request (rather than require) a client certificate, without LittleProxy overriding the SSLEngine's client-auth configuration:

- ProxyConnection.encrypt() now calls setNeedClientAuth(true) only when authenticateClients is true; when false, the SSLEngine's client-auth setting is left exactly as the SslEngineSource created it
- This lets an SslEngineSource opt into setWantClientAuth(true) (or Netty's ClientAuth.OPTIONAL), which was previously always reset to need-auth
- Updated Javadoc on both encrypt() overloads and on HttpProxyServerBootstrap.withAuthenticateSslClients(boolean) to document the new "leave the engine untouched" semantics for authenticateClients=false

Backward compatible: the default authenticateSslClients=true continues to map to setNeedClientAuth(true); for false, the previous setNeedClientAuth(false) was a no-op on a freshly created engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL connection handling when client authentication is disabled.
  * Preserved existing optional or disabled client-authentication settings instead of overriding them.
  * Ensured required client authentication is enabled when requested.

* **Tests**
  * Added coverage for required, optional, disabled, and unauthenticated SSL configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->