### PR TITLE
2.9.1: Bump Selenium from 4.47.0 to 4.48.0

### DIFF
--- a/PERFORMANCE_AND_LOGGING.md
+++ b/PERFORMANCE_AND_LOGGING.md
@@ -72,7 +72,7 @@ This guide covers logging performance optimization techniques and configuration 
 
 # Direct Java command
 java -server -XX:+HeapDumpOnOutOfMemoryError -Xmx800m \
-  -jar ./target/littleproxy-2.9.0-littleproxy-shade.jar \
+  -jar ./target/littleproxy-2.9.1-littleproxy-shade.jar \
   --server --config ./config/littleproxy.properties --port 9092 \
   --log_config ./target/classes/littleproxy_async_log4j2.xml
 ```
@@ -581,7 +581,7 @@ Add debug output to Log4j2:
 ```bash
 # Check async logger buffer status
 java -Dlog4j2.AsyncLoggerConfig.StatusLogger.level=INFO \
-  -jar ./target/littleproxy-2.9.0-littleproxy-shade.jar \
+  -jar ./target/littleproxy-2.9.1-littleproxy-shade.jar \
   --server --config ./config/littleproxy.properties --port 9092
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ You can embed LittleProxy in your own projects through Maven with the following 
     <dependency>
         <groupId>io.github.littleproxy</groupId>
         <artifactId>littleproxy</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </dependency>
 ```
 
 Or with Gradle like this
 
-`implementation "io.github.littleproxy:littleproxy:2.9.0"`
+`implementation "io.github.littleproxy:littleproxy:2.9.1"`
 
 Once you've included LittleProxy, you can start the server with the following:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+- 2.9.1 (28.08.2026, https://github.com/LittleProxy/LittleProxy/milestone/53?closed=1)
+  - Bump Netty from 4.2.16.Final to 4.2.17.Final (#782)
+  - Bump Selenium from 4.46.0 to 4.48.0 (#784) (#792)
+  - Bump Guava from 33.6.0-jre to 33.7.1-jre (#787) (#788)
+
 - 2.9.0 (06.08.2026, https://github.com/LittleProxy/LittleProxy/milestone/52?closed=1)
   - #737 Fix order of handlers to support proxy protocol decoding for inbound requests (#729) by Krasimir Marinov
   - fix "IllegalReferenceCountException: null" on ClientToProxyConnection (#625) by James Baldassari

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>io.github.littleproxy</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>2.10.0-SNAPSHOT</version>
+    <version>2.9.1</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
@@ -35,7 +35,7 @@
         <log4j.version>2.26.1</log4j.version>
         <mockito.version>5.23.0</mockito.version>
         <netty.version>4.2.17.Final</netty.version>
-        <selenium.version>4.47.0</selenium.version>
+        <selenium.version>4.48.0</selenium.version>
         <slf4j.version>2.0.18</slf4j.version>
         <wiremock.version>3.13.2</wiremock.version>
     </properties>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 2.9.1.

* **Documentation**
  * Updated setup instructions and command examples for version 2.9.1.
  * Added release notes covering dependency updates.

* **Chores**
  * Updated Selenium to version 4.48.0.
  * Updated Netty, Guava, and other dependency references in the release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->